### PR TITLE
[AG-92] setting the credentials for recovery when array is null or empty

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionFactory.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionFactory.java
@@ -154,7 +154,7 @@ public final class ConnectionFactory implements ResourceRecoveryFactory {
         setupSecurity( jdbcProperties, configuration.principal(), configuration.credentials() );
 
         // use the main credentials when recovery credentials are not provided
-        if ( configuration.recoveryPrincipal() == null && configuration.recoveryCredentials() == null ) {
+        if ( configuration.recoveryPrincipal() == null && (configuration.recoveryCredentials() == null || configuration.recoveryCredentials().isEmpty())) {
             setupSecurity( recoveryProperties, configuration.principal(), configuration.credentials() );
         } else {
             setupSecurity( recoveryProperties, configuration.recoveryPrincipal(), configuration.recoveryCredentials() );


### PR DESCRIPTION
based on the default settings the credentials for recovery is not `null` by default but it could be empty array: https://github.com/agroal/agroal/blob/master/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalConnectionFactoryConfigurationSupplier.java#L35