### PR TITLE
AG-69 - Agroal pooless datasource

### DIFF
--- a/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionPoolConfiguration.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionPoolConfiguration.java
@@ -32,6 +32,8 @@ public interface AgroalConnectionPoolConfiguration {
 
     Duration maxLifetime();
 
+    boolean flushOnClose();
+
     int initialSize();
 
     // --- Mutable attributes //

--- a/agroal-api/src/main/java/io/agroal/api/configuration/AgroalDataSourceConfiguration.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/AgroalDataSourceConfiguration.java
@@ -25,6 +25,7 @@ public interface AgroalDataSourceConfiguration {
     enum DataSourceImplementation {
 
         AGROAL( "io.agroal.pool.DataSource" ),
+        AGROAL_POOLLESS( "io.agroal.pool.DataSource" ),
         HIKARI( "io.agroal.hikari.HikariUnderTheCovers" );
 
         private final String className;

--- a/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalConnectionPoolConfigurationSupplier.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalConnectionPoolConfigurationSupplier.java
@@ -27,6 +27,7 @@ public class AgroalConnectionPoolConfigurationSupplier implements Supplier<Agroa
     private AgroalConnectionFactoryConfigurationSupplier connectionFactoryConfigurationSupplier = new AgroalConnectionFactoryConfigurationSupplier();
 
     private TransactionIntegration transactionIntegration = none();
+    private boolean flushOnClose = false;
     private int initialSize = 0;
     private volatile int minSize = 0;
     private volatile int maxSize = MAX_VALUE;
@@ -50,6 +51,7 @@ public class AgroalConnectionPoolConfigurationSupplier implements Supplier<Agroa
         }
         this.connectionFactoryConfigurationSupplier = new AgroalConnectionFactoryConfigurationSupplier( existingConfiguration.connectionFactoryConfiguration() );
         this.transactionIntegration = existingConfiguration.transactionIntegration();
+        this.flushOnClose = existingConfiguration.flushOnClose();
         this.initialSize = existingConfiguration.initialSize();
         this.minSize = existingConfiguration.minSize();
         this.maxSize = existingConfiguration.maxSize();
@@ -92,6 +94,16 @@ public class AgroalConnectionPoolConfigurationSupplier implements Supplier<Agroa
     public AgroalConnectionPoolConfigurationSupplier transactionIntegration(TransactionIntegration integration) {
         checkLock();
         transactionIntegration =  integration;
+        return this;
+    }
+
+    public AgroalConnectionPoolConfigurationSupplier flushOnClose() {
+        return flushOnClose( true );
+    }
+    
+    public AgroalConnectionPoolConfigurationSupplier flushOnClose(boolean flush) {
+        checkLock();
+        flushOnClose = flush;
         return this;
     }
 
@@ -218,6 +230,11 @@ public class AgroalConnectionPoolConfigurationSupplier implements Supplier<Agroa
             @Override
             public TransactionIntegration transactionIntegration() {
                 return transactionIntegration;
+            }
+
+            @Override
+            public boolean flushOnClose() {
+                return flushOnClose;
             }
 
             @Override

--- a/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalPropertiesReader.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalPropertiesReader.java
@@ -38,6 +38,7 @@ public class AgroalPropertiesReader implements Supplier<AgroalDataSourceConfigur
     public static final String MIN_SIZE = "minSize";
     public static final String MAX_SIZE = "maxSize";
     public static final String INITIAL_SIZE = "initialSize";
+    public static final String FLUSH_ON_CLOSE = "flushOnClose";
     public static final String ACQUISITION_TIMEOUT = "acquisitionTimeout";
     public static final String ACQUISITION_TIMEOUT_MS = "acquisitionTimeout_ms";
     public static final String ACQUISITION_TIMEOUT_S = "acquisitionTimeout_s";
@@ -129,6 +130,7 @@ public class AgroalPropertiesReader implements Supplier<AgroalDataSourceConfigur
 
         apply( connectionPoolSupplier::minSize, Integer::parseInt, properties, MIN_SIZE );
         apply( connectionPoolSupplier::maxSize, Integer::parseInt, properties, MAX_SIZE );
+        apply( connectionPoolSupplier::flushOnClose, Boolean::parseBoolean, properties, FLUSH_ON_CLOSE );
         apply( connectionPoolSupplier::initialSize, Integer::parseInt, properties, INITIAL_SIZE );
 
         apply( connectionPoolSupplier::acquisitionTimeout, Duration::parse, properties, ACQUISITION_TIMEOUT );

--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
@@ -44,7 +44,7 @@ public final class ConnectionHandler implements TransactionAware {
     //used in XA mode, otherwise null
     private final XAResource xaResource;
 
-    private final ConnectionPool connectionPool;
+    private final Pool connectionPool;
 
     // attributes that need to be reset when the connection is returned
     private final Set<DirtyAttribute> dirtyAttributes = noneOf( DirtyAttribute.class );
@@ -73,7 +73,7 @@ public final class ConnectionHandler implements TransactionAware {
     // If there is no transaction integration this should just return false
     private TransactionAware.SQLCallable<Boolean> transactionActiveCheck = NO_ACTIVE_TRANSACTION;
 
-    public ConnectionHandler(XAConnection xaConnection, ConnectionPool pool) throws SQLException {
+    public ConnectionHandler(XAConnection xaConnection, Pool pool) throws SQLException {
         connection = xaConnection.getConnection();
         xaResource = xaConnection.getXAResource();
 

--- a/agroal-pool/src/main/java/io/agroal/pool/DataSource.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/DataSource.java
@@ -22,11 +22,16 @@ public final class DataSource implements AgroalDataSource {
     private static final long serialVersionUID = 6485903416474487024L;
 
     private final AgroalDataSourceConfiguration configuration;
-    private final ConnectionPool connectionPool;
+    private final Pool connectionPool;
 
     public DataSource(AgroalDataSourceConfiguration dataSourceConfiguration, AgroalDataSourceListener... listeners) {
         configuration = dataSourceConfiguration;
-        connectionPool = new ConnectionPool( dataSourceConfiguration.connectionPoolConfiguration(), listeners );
+        if ( configuration.dataSourceImplementation() == AgroalDataSourceConfiguration.DataSourceImplementation.AGROAL_POOLLESS ) {
+            connectionPool = new Poolless( dataSourceConfiguration.connectionPoolConfiguration(), listeners );
+        } else {
+            connectionPool = new ConnectionPool( dataSourceConfiguration.connectionPoolConfiguration(), listeners );
+        }
+
         dataSourceConfiguration.registerMetricsEnabledListener( connectionPool );
         connectionPool.onMetricsEnabled( dataSourceConfiguration.metricsEnabled() );
         connectionPool.init();
@@ -46,7 +51,7 @@ public final class DataSource implements AgroalDataSource {
 
     @Override
     public void flush(FlushMode mode) {
-        connectionPool.flush(mode);
+        connectionPool.flushPool(mode);
     }
 
     @Override

--- a/agroal-pool/src/main/java/io/agroal/pool/DataSourceProvider.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/DataSourceProvider.java
@@ -9,6 +9,7 @@ import io.agroal.api.AgroalDataSourceProvider;
 import io.agroal.api.configuration.AgroalDataSourceConfiguration;
 
 import static io.agroal.api.configuration.AgroalDataSourceConfiguration.DataSourceImplementation.AGROAL;
+import static io.agroal.api.configuration.AgroalDataSourceConfiguration.DataSourceImplementation.AGROAL_POOLLESS;
 
 /**
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
@@ -17,6 +18,6 @@ public final class DataSourceProvider implements AgroalDataSourceProvider {
 
     @Override
     public AgroalDataSource getDataSource(AgroalDataSourceConfiguration config, AgroalDataSourceListener... listeners) {
-        return config.dataSourceImplementation() == AGROAL ? new DataSource( config, listeners ) : null;
+        return config.dataSourceImplementation() == AGROAL || config.dataSourceImplementation() == AGROAL_POOLLESS ? new DataSource( config, listeners ) : null;
     }
 }

--- a/agroal-pool/src/main/java/io/agroal/pool/DefaultMetricsRepository.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/DefaultMetricsRepository.java
@@ -22,7 +22,7 @@ public final class DefaultMetricsRepository implements MetricsRepository {
     private static final String FORMAT_4 = "Acquire duration: {0,number,000.000}ms average | {1}ms max | {2}ms total";
     private static final String FORMAT_5 = "Threads awaiting: {0}";
 
-    private final ConnectionPool connectionPool;
+    private final Pool connectionPool;
     private final LongAdder creationCount = new LongAdder();
     private final LongAdder creationTotalTime = new LongAdder();
     private final LongAdder acquireCount = new LongAdder();
@@ -36,7 +36,7 @@ public final class DefaultMetricsRepository implements MetricsRepository {
     private final LongAccumulator maxCreatedDuration = new LongAccumulator( Long::max, 0 );
     private final LongAccumulator maxAcquireDuration = new LongAccumulator( Long::max, 0 );
 
-    public DefaultMetricsRepository(ConnectionPool pool) {
+    public DefaultMetricsRepository(Pool pool) {
         this.connectionPool = pool;
     }
 

--- a/agroal-pool/src/main/java/io/agroal/pool/Pool.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/Pool.java
@@ -1,0 +1,48 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.pool;
+
+import io.agroal.api.AgroalDataSource.FlushMode;
+import io.agroal.api.AgroalDataSourceListener;
+import io.agroal.api.AgroalDataSourceMetrics;
+import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
+import io.agroal.api.configuration.AgroalDataSourceConfiguration.MetricsEnabledListener;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
+ */
+public interface Pool extends MetricsEnabledListener, AutoCloseable {
+
+    void init();
+
+    Connection getConnection() throws SQLException;
+
+    AgroalConnectionPoolConfiguration getConfiguration();
+
+    AgroalDataSourceMetrics getMetrics();
+
+    AgroalDataSourceListener[] getListeners();
+
+    void returnConnectionHandler(ConnectionHandler handler) throws SQLException;
+
+    void flushPool(FlushMode mode);
+
+    @Override
+    void close();
+
+    // --- exposed statistics //
+
+    long activeCount();
+
+    long maxUsedCount();
+
+    long availableCount();
+
+    long awaitingCount();
+
+    void resetMaxUsedCount();
+}

--- a/agroal-pool/src/main/java/io/agroal/pool/Poolless.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/Poolless.java
@@ -1,0 +1,267 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.pool;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.AgroalDataSourceListener;
+import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
+import io.agroal.api.transaction.TransactionIntegration;
+import io.agroal.pool.MetricsRepository.EmptyMetricsRepository;
+import io.agroal.pool.util.AgroalSynchronizer;
+import io.agroal.pool.util.StampedCopyOnWriteArrayList;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAccumulator;
+
+import static io.agroal.api.AgroalDataSource.FlushMode.ALL;
+import static io.agroal.pool.ConnectionHandler.State.CHECKED_OUT;
+import static io.agroal.pool.ConnectionHandler.State.DESTROYED;
+import static io.agroal.pool.ConnectionHandler.State.FLUSH;
+import static io.agroal.pool.util.ListenerHelper.*;
+import static java.lang.System.nanoTime;
+import static java.lang.Thread.currentThread;
+
+/**
+ * Alternative implementation of ConnectionPool for the special case of flush-on-close (and min-size == 0)
+ * In particular, this removes the need for the executor. Also there is no thread-local connection cache as connections are not reused
+ *
+ * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
+ */
+public final class Poolless implements Pool {
+
+    private final AgroalConnectionPoolConfiguration configuration;
+    private final AgroalDataSourceListener[] listeners;
+
+    private final StampedCopyOnWriteArrayList<ConnectionHandler> allConnections;
+
+    private final AgroalSynchronizer synchronizer;
+    private final ConnectionFactory connectionFactory;
+    private final TransactionIntegration transactionIntegration;
+
+    private final LongAccumulator maxUsed = new LongAccumulator( Math::max, Long.MIN_VALUE );
+    private final AtomicInteger activeCount = new AtomicInteger();
+
+    private MetricsRepository metricsRepository;
+    private volatile boolean shutdown;
+
+    public Poolless(AgroalConnectionPoolConfiguration configuration, AgroalDataSourceListener... listeners) {
+        this.configuration = configuration;
+        this.listeners = listeners;
+
+        allConnections = new StampedCopyOnWriteArrayList<>( ConnectionHandler.class );
+
+        synchronizer = new AgroalSynchronizer();
+        connectionFactory = new ConnectionFactory( configuration.connectionFactoryConfiguration(), listeners );
+        transactionIntegration = configuration.transactionIntegration();
+    }
+
+    public void init() {
+        if ( !configuration.maxLifetime().isZero() ) {
+            fireOnWarning( listeners, "Max lifetime not supported in pool-less mode" );
+        }
+        if ( !configuration.idleValidationTimeout().isZero() ) {
+            fireOnWarning( listeners, "Idle validation not supported in pool-less mode" );
+        }
+        if ( !configuration.leakTimeout().isZero() ) {
+            fireOnWarning( listeners, "Leak detection not supported in pool-less mode" );
+        }
+        if ( !configuration.reapTimeout().isZero() ) {
+            fireOnWarning( listeners, "Connection reap not supported in pool-less mode" );
+        }
+        if ( configuration.initialSize() != 0 ) {
+            fireOnWarning( listeners, "Initial size is zero in pool-less mode" );
+        }
+        if ( configuration.minSize() != 0 ) {
+            fireOnWarning( listeners, "Min size always zero in pool-less mode" );
+        }
+
+        transactionIntegration.addResourceRecoveryFactory( connectionFactory );
+    }
+
+    public AgroalConnectionPoolConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    public AgroalDataSourceListener[] getListeners() {
+        return listeners;
+    }
+
+    // --- //
+
+    @Override
+    public void close() {
+        transactionIntegration.removeResourceRecoveryFactory( connectionFactory );
+        shutdown = true;
+
+        for ( ConnectionHandler handler : allConnections ) {
+            handler.setState( FLUSH );
+            destroyConnection( handler );
+        }
+        allConnections.clear();
+
+        synchronizer.release( synchronizer.getQueueLength() );
+    }
+
+    // --- //
+
+    public Connection getConnection() throws SQLException {
+        fireBeforeConnectionAcquire( listeners );
+        long metricsStamp = metricsRepository.beforeConnectionAcquire();
+
+        if ( shutdown ) {
+            throw new SQLException( "This pool is closed and does not handle any more connections!" );
+        }
+
+        ConnectionHandler checkedOutHandler = handlerFromTransaction();
+        if ( checkedOutHandler == null ) {
+            checkedOutHandler = handlerFromSharedCache();
+        }
+
+        metricsRepository.afterConnectionAcquire( metricsStamp );
+        fireOnConnectionAcquired( listeners, checkedOutHandler );
+
+        transactionIntegration.associate( checkedOutHandler, checkedOutHandler.getXaResource() );
+        return checkedOutHandler.newConnectionWrapper();
+    }
+
+    private ConnectionHandler handlerFromTransaction() throws SQLException {
+        return (ConnectionHandler) transactionIntegration.getTransactionAware();
+    }
+
+    private ConnectionHandler handlerFromSharedCache() throws SQLException {
+        long remaining = configuration.acquisitionTimeout().toNanos();
+        remaining = remaining > 0 ? remaining : Long.MAX_VALUE;
+        try {
+            for ( ; ; ) {
+                // Try to get a "token" to create a new connection
+                if ( activeCount.incrementAndGet() <= configuration.maxSize() ) {
+                    return createConnection();
+                } else {
+                    activeCount.decrementAndGet();
+                }
+
+                // Pool full, will have to wait for a connection to be returned
+                long synchronizationStamp = synchronizer.getStamp();
+                long start = nanoTime();
+                if ( remaining < 0 || !synchronizer.tryAcquireNanos( synchronizationStamp, remaining ) ) {
+                    throw new SQLException( "Sorry, acquisition timeout!" );
+                }
+                if ( shutdown ) {
+                    throw new SQLException( "Can't create new connection as the pool is shutting down" );
+                }
+                remaining -= nanoTime() - start;
+            }
+        } catch ( InterruptedException e ) {
+            currentThread().interrupt();
+            throw new SQLException( "Interrupted while acquiring" );
+        }
+    }
+
+    // --- //
+
+    public void returnConnectionHandler(ConnectionHandler handler) throws SQLException {
+        fireBeforeConnectionReturn( listeners, handler );
+        if ( transactionIntegration.disassociate( handler ) ) {
+            activeCount.decrementAndGet();
+            synchronizer.releaseConditional();
+
+            flushHandler( handler );
+        }
+    }
+
+    // --- Exposed statistics //
+
+    @Override
+    public void onMetricsEnabled(boolean metricsEnabled) {
+        setMetricsRepository( metricsEnabled ? new DefaultMetricsRepository( this ) : new EmptyMetricsRepository() );
+    }
+
+    public MetricsRepository getMetrics() {
+        return metricsRepository;
+    }
+
+    public void setMetricsRepository(MetricsRepository metricsRepository) {
+        this.metricsRepository = metricsRepository;
+    }
+
+    public long activeCount() {
+        return allConnections.size();
+    }
+
+    public long availableCount() {
+        return 0;
+    }
+
+    public long maxUsedCount() {
+        return maxUsed.get();
+    }
+
+    public void resetMaxUsedCount() {
+        maxUsed.reset();
+    }
+
+    public long awaitingCount() {
+        return synchronizer.getQueueLength();
+    }
+
+    // --- create //
+
+    public ConnectionHandler createConnection() throws SQLException {
+        fireBeforeConnectionCreation( listeners );
+        long metricsStamp = metricsRepository.beforeConnectionCreation();
+
+        try {
+            ConnectionHandler handler = new ConnectionHandler( connectionFactory.createConnection(), this );
+
+            fireOnConnectionCreation( listeners, handler );
+            metricsRepository.afterConnectionCreation( metricsStamp );
+
+            handler.setState( CHECKED_OUT );
+            allConnections.add( handler );
+
+            maxUsed.accumulate( allConnections.size() );
+            fireOnConnectionPooled( listeners, handler );
+
+            return handler;
+        } catch ( SQLException e ) {
+            fireOnWarning( listeners, e );
+            throw e;
+        }
+    }
+
+    // --- flush //
+
+    public void flushPool(AgroalDataSource.FlushMode mode) {
+        if ( mode == ALL ) {
+            for ( ConnectionHandler handler : allConnections ) {
+                fireBeforeConnectionFlush( listeners, handler );
+                flushHandler( handler );
+            }
+        }
+    }
+
+    public void flushHandler(ConnectionHandler handler) {
+        handler.setState( FLUSH );
+        allConnections.remove( handler );
+        metricsRepository.afterConnectionFlush();
+        fireOnConnectionFlush( listeners, handler );
+        destroyConnection( handler );
+    }
+
+    // --- destroy //
+
+    public void destroyConnection(ConnectionHandler handler) {
+        fireBeforeConnectionDestroy( listeners, handler );
+        try {
+            handler.closeConnection();
+        } catch ( SQLException e ) {
+            fireOnWarning( listeners, e );
+        }
+        handler.setState( DESTROYED );
+        metricsRepository.afterConnectionDestroy();
+        fireOnConnectionDestroy( listeners, handler );
+    }
+}

--- a/agroal-test/src/test/java/io/agroal/test/basic/PoollessTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/PoollessTests.java
@@ -1,0 +1,175 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.basic;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.AgroalDataSourceListener;
+import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Logger;
+
+import static io.agroal.api.configuration.AgroalDataSourceConfiguration.DataSourceImplementation.AGROAL_POOLLESS;
+import static io.agroal.test.AgroalTestGroup.FUNCTIONAL;
+import static io.agroal.test.MockDriver.deregisterMockDriver;
+import static io.agroal.test.MockDriver.registerMockDriver;
+import static java.lang.Thread.currentThread;
+import static java.text.MessageFormat.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.logging.Logger.getLogger;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
+ */
+@Tag( FUNCTIONAL )
+public class PoollessTests {
+
+    private static final Logger logger = getLogger( PoollessTests.class.getName() );
+
+    @BeforeAll
+    public static void setupMockDriver() {
+        registerMockDriver();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        deregisterMockDriver();
+    }
+
+    // --- //
+
+    @Test
+    @DisplayName( "Pool-less Test" )
+    public void poollessTest() throws SQLException {
+        int TIMEOUT_MS = 100, NUM_THREADS = 4;
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .dataSourceImplementation( AGROAL_POOLLESS )
+                .metricsEnabled()
+                .connectionPoolConfiguration( cp -> cp
+                        .initialSize( 1 ) // ignored
+                        .minSize( 1 ) // ignored
+                        .maxSize( 2 )
+                        .acquisitionTimeout( Duration.ofMillis( 5 * TIMEOUT_MS ) )
+                );
+
+        CountDownLatch destroyLatch = new CountDownLatch( 1 );
+
+        AgroalDataSourceListener listener = new AgroalDataSourceListener() {
+            @Override
+            public void onConnectionDestroy(Connection connection) {
+                destroyLatch.countDown();
+            }
+
+            @Override
+            public void onWarning(String message) {
+                logger.info( message );
+            }
+
+            @Override
+            public void onWarning(Throwable throwable) {
+                fail( throwable );
+            }
+        };
+
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, listener ) ) {
+            assertEquals( 0, dataSource.getMetrics().creationCount() );
+
+            try ( Connection c = dataSource.getConnection() ) {
+                assertFalse( c.isClosed() );
+
+                try ( Connection testSubject = dataSource.getConnection() ) {
+                    assertFalse( testSubject.isClosed() );
+
+                    assertEquals( 2, dataSource.getMetrics().creationCount() );
+                    assertThrows( SQLException.class, dataSource::getConnection, "Expected exception due to pool being full" );
+                    assertEquals( 2, dataSource.getMetrics().creationCount() );
+                }
+
+                logger.info( format( "Waiting for destruction of connection" ) );
+                if ( !destroyLatch.await( 2 * TIMEOUT_MS, MILLISECONDS ) ) {
+                    fail( format( "Flushed connections not sent for destruction" ) );
+                }
+
+                // One connection flushed and another in use
+                assertEquals( 1, dataSource.getMetrics().flushCount() );
+                assertEquals( 0, dataSource.getMetrics().availableCount() );
+            }
+
+            // Assert min-size is zero
+            assertEquals( 0, dataSource.getMetrics().activeCount() );
+            assertEquals( 0, dataSource.getMetrics().availableCount() );
+
+            // Assert that closing a connection unblocks one waiting thread
+            assertDoesNotThrow( () -> {
+                Connection c = dataSource.getConnection();
+                dataSource.getConnection();
+
+                // just one of this threads will unblock
+                Collection<Thread> threads = new ArrayList<>( NUM_THREADS );
+                for ( int i = 0; i < NUM_THREADS; i++ ) {
+                    threads.add( newConnectionThread( dataSource ) );
+                }
+                threads.forEach( Thread::start );
+
+                try {
+                    Thread.sleep( TIMEOUT_MS );
+                    assertEquals( 4, dataSource.getMetrics().awaitingCount(), "Insufficient number of blocked threads" );
+                    assertEquals( 4, dataSource.getMetrics().creationCount() );
+
+                    logger.info( "Closing connection to unblock one waiting thread" );
+                    c.close();
+
+                    Thread.sleep( TIMEOUT_MS );
+
+                    assertEquals( 3, dataSource.getMetrics().awaitingCount(), "Insufficient number of blocked threads" );
+                    assertEquals( 5, dataSource.getMetrics().creationCount() );
+
+                    for ( Thread thread : threads ) {
+                        thread.join( TIMEOUT_MS );
+                    }
+                } catch ( InterruptedException e ) {
+                    fail( e );
+                }
+            } );
+        } catch ( InterruptedException e ) {
+            fail( "Test fail due to interrupt" );
+        }
+
+        try {
+            Thread.sleep( TIMEOUT_MS );
+        } catch ( InterruptedException e ) {
+            //
+        }
+    }
+
+    private Thread newConnectionThread(DataSource dataSource) {
+        return new Thread( () -> {
+            logger.info( currentThread().getName() + " is on the race for a connection" );
+            try {
+                Connection c = dataSource.getConnection();
+                assertFalse( c.isClosed() );
+                logger.info( currentThread().getName() + " got one connection !!!" );
+            } catch ( SQLException e ) {
+                logger.info( currentThread().getName() + " got none" );
+            }
+        } );
+    }
+}


### PR DESCRIPTION
Adds a new configuration to the pool, ```flushOnClose```,  that forces connections to be flush as they return to the pool. 

Also, adds a completely new pool for this use case, as there are several important optimizations that can be leveraged. This mode is selected as a new DataSource implementation, ```AGROAL_POOLLESS```