### PR TITLE
Resource leak report fixes

### DIFF
--- a/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalConnectionFactoryConfigurationSupplier.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalConnectionFactoryConfigurationSupplier.java
@@ -123,7 +123,7 @@ public class AgroalConnectionFactoryConfigurationSupplier implements Supplier<Ag
     }
 
     /**
-     * Attempts to load a JDBC driver class using it's fully qualified name. The classloader used is the one of this class.
+     * Attempts to load a JDBC driver class using its fully qualified name. The classloader used is the one of this class.
      * This method throws Exception if the class can't be loaded.
      */
     public AgroalConnectionFactoryConfigurationSupplier connectionProviderClassName(String connectionProviderName) {

--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
@@ -92,7 +92,7 @@ public final class ConnectionHandler implements TransactionAware {
 
     public void onConnectionWrapperClose(ConnectionWrapper wrapper, ConnectionWrapper.JdbcResourcesLeakReport leakReport) throws SQLException {
         if ( leakReport.hasLeak() ) {
-            fireOnWarning( connectionPool.getListeners(), "JDBC resources leaked: " + leakReport.resultSetCount() + " ResultSet on " + leakReport.resultSetCount() + " Statement" );
+            fireOnWarning( connectionPool.getListeners(), "JDBC resources leaked: " + leakReport.resultSetCount() + " ResultSet(s) and " + leakReport.statementCount() + " Statement(s)" );
         }
         if ( enlisted ) {
             enlistedOpenWrappers.remove( wrapper );


### PR DESCRIPTION
It was reporting `resultSetCount` twice, while not reporting `statementCount`.

Also improved the wording a bit, as I wasn't sure how to interpret it.

It found leak in our code!