### PR TITLE
AG-131 - Change data structure used to track JDBC resources

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
@@ -4,7 +4,6 @@
 package io.agroal.pool.wrapper;
 
 import io.agroal.pool.ConnectionHandler;
-import io.agroal.pool.util.StampedCopyOnWriteArrayList;
 
 import java.lang.reflect.InvocationHandler;
 import java.sql.Array;
@@ -25,6 +24,7 @@ import java.sql.Struct;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 
 import static java.lang.reflect.Proxy.newProxyInstance;
@@ -68,7 +68,7 @@ public final class ConnectionWrapper implements Connection {
     public ConnectionWrapper(ConnectionHandler connectionHandler, boolean trackResources) {
         handler = connectionHandler;
         wrappedConnection = connectionHandler.getConnection();
-        trackedStatements = trackResources ? new StampedCopyOnWriteArrayList<>( Statement.class ) : null;
+        trackedStatements = trackResources ? new ConcurrentLinkedQueue<>() : null;
     }
 
     public ConnectionHandler getHandler() {

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/StatementWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/StatementWrapper.java
@@ -3,8 +3,6 @@
 
 package io.agroal.pool.wrapper;
 
-import io.agroal.pool.util.StampedCopyOnWriteArrayList;
-
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.sql.Connection;
@@ -13,6 +11,7 @@ import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static java.lang.reflect.Proxy.newProxyInstance;
 
@@ -52,7 +51,7 @@ public class StatementWrapper implements Statement {
     public StatementWrapper(ConnectionWrapper connectionWrapper, Statement statement, boolean trackResources) {
         connection = connectionWrapper;
         wrappedStatement = statement;
-        trackedResultSets = trackResources ? new StampedCopyOnWriteArrayList<>( ResultSet.class ) : null;
+        trackedResultSets = trackResources ? new ConcurrentLinkedQueue<>() : null;
     }
 
     // --- //


### PR DESCRIPTION
The current data structure is optimized for when the number of reads far exceeds the number of writes, which is the opposite of what we want here. 

I believe that because there will be mostly add / remove operations, a data structure backed by an array may not be the best fit for this use case, therefore ended up going with ``ConcurrentLinkedQueue``.
 