### PR TITLE
AG-154 - SQLException during reset leaks connection

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
@@ -132,16 +132,20 @@ public final class ConnectionHandler implements TransactionAware {
             dirtyAttributes.clear();
         }
 
-        SQLWarning warning = connection.getWarnings();
-        if ( warning != null ) {
-            AgroalConnectionPoolConfiguration.ExceptionSorter exceptionSorter = connectionPool.getConfiguration().exceptionSorter();
-            while ( warning != null ) {
-                if ( exceptionSorter != null && exceptionSorter.isFatal( warning ) ) {
-                    setState( State.FLUSH );
+        try {
+            SQLWarning warning = connection.getWarnings();
+            if ( warning != null ) {
+                AgroalConnectionPoolConfiguration.ExceptionSorter exceptionSorter = connectionPool.getConfiguration().exceptionSorter();
+                while ( warning != null ) {
+                    if ( exceptionSorter != null && exceptionSorter.isFatal( warning ) ) {
+                        setState( State.FLUSH );
+                    }
+                    warning = warning.getNextWarning();
                 }
-                warning = warning.getNextWarning();
+                connection.clearWarnings();
             }
-            connection.clearWarnings();
+        } catch ( SQLException sqlException ) {
+            // keep errors
         }
     }
 

--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
@@ -367,7 +367,11 @@ public final class ConnectionPool implements Pool {
             return;
         }
 
-        handler.resetConnection();
+        try {
+            handler.resetConnection();
+        } catch ( SQLException sqlException ) {
+            fireOnWarning( listeners, sqlException );
+        }
         localCache.get().add( handler );
         fireOnConnectionReturnInterceptor( interceptors, handler );
 


### PR DESCRIPTION
Fires a warning when the exception occurs when resetting dirty attributes. If it happens when dealing with SQLWarning, leave silently and keep the warnings on the connection. 