### PR TITLE
AG-167 - Prevent connection return after XA completion

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
@@ -316,6 +316,10 @@ public final class ConnectionHandler implements TransactionAware {
 
     @Override
     public void transactionEnd() throws SQLException {
+        for ( ConnectionWrapper wrapper : enlistedOpenWrappers ) {
+            fireOnWarning( connectionPool.getListeners(), "Closing open connection after completion" );
+            wrapper.close();
+        }
         enlisted = false;
         connectionPool.returnConnectionHandler( this );
     }


### PR DESCRIPTION
We don't verify if there are outstanding open wrappers on `transactionEnd()` as this already happens before on `transactionCommit()` or `transactionRollback()`, but this methods are only invoked as a local resource and not on XA.

After `transactionEnd()` the connection is back on the pool and a call to `close()` on an open wrapper will attempt to put it back, leading to caos as the state is not correct.