### PR TITLE
Log interceptors at the debug level

### DIFF
--- a/agroal-api/src/main/java/io/agroal/api/AgroalDataSourceListener.java
+++ b/agroal-api/src/main/java/io/agroal/api/AgroalDataSourceListener.java
@@ -120,4 +120,9 @@ public interface AgroalDataSourceListener {
      */
     default void onInfo(String message) {}
 
+    /**
+     * Callback to allow reporting information of interest, for which a info might be considered excessive.
+     */
+    default void onDebug(String message) {}
+
 }

--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
@@ -56,6 +56,7 @@ import static io.agroal.pool.util.ListenerHelper.fireOnConnectionPooled;
 import static io.agroal.pool.util.ListenerHelper.fireOnConnectionReap;
 import static io.agroal.pool.util.ListenerHelper.fireOnConnectionReturn;
 import static io.agroal.pool.util.ListenerHelper.fireOnConnectionValid;
+import static io.agroal.pool.util.ListenerHelper.fireOnDebug;
 import static io.agroal.pool.util.ListenerHelper.fireOnInfo;
 import static io.agroal.pool.util.ListenerHelper.fireOnWarning;
 import static java.lang.Integer.toHexString;
@@ -169,7 +170,7 @@ public final class ConnectionPool implements Pool {
         interceptors = list.stream().sorted( AgroalPoolInterceptor.DEFAULT_COMPARATOR ).collect( toList() );
 
         Function<AgroalPoolInterceptor, String> interceptorName = i -> i.getClass().getName() + "@" + toHexString( identityHashCode( i ) ) + " (priority " + i.getPriority() + ")";
-        fireOnInfo( listeners, "Pool interceptors: " + interceptors.stream().map( interceptorName ).collect( joining( " >>> ", "[", "]" ) ) );
+        fireOnDebug( listeners, "Pool interceptors: " + interceptors.stream().map( interceptorName ).collect( joining( " >>> ", "[", "]" ) ) );
     }
 
     public void flushPool(AgroalDataSource.FlushMode mode) {

--- a/agroal-pool/src/main/java/io/agroal/pool/util/ListenerHelper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/util/ListenerHelper.java
@@ -162,4 +162,10 @@ public final class ListenerHelper {
             listener.onInfo( message );
         }
     }
+
+    public static void fireOnDebug(AgroalDataSourceListener[] listeners, String message) {
+        for ( AgroalDataSourceListener listener : listeners ) {
+            listener.onDebug( message );
+        }
+    }
 }


### PR DESCRIPTION
Showing the interceptors at the INFO log level can be annoying, so it's probably best done at DEBUG.
This is essentially what https://github.com/quarkusio/quarkus/issues/28804 is about