### PR TITLE
Upgrade to Narayana 6.0.0.Final

### DIFF
--- a/agroal-narayana/pom.xml
+++ b/agroal-narayana/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>
-            <artifactId>jboss-transaction-spi-jakarta</artifactId>
+            <artifactId>jboss-transaction-spi</artifactId>
             <version>${version.org.jboss.jboss-transaction-spi}</version>
         </dependency>
     </dependencies>

--- a/agroal-test/pom.xml
+++ b/agroal-test/pom.xml
@@ -94,13 +94,13 @@
         <!-- Narayana -->
         <dependency>
             <groupId>org.jboss.narayana.jta</groupId>
-            <artifactId>narayana-jta-jakarta</artifactId>
+            <artifactId>narayana-jta</artifactId>
             <version>${version.org.jboss.narayana}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
-            <artifactId>narayana-jts-integration-jakarta</artifactId>
+            <artifactId>narayana-jts-integration</artifactId>
             <version>${version.org.jboss.narayana}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
         <version.com.zaxxer>4.0.3</version.com.zaxxer>
         <version.me.snowdrop>2.6.1</version.me.snowdrop>
         <version.org.apache.felix>7.0.3</version.org.apache.felix>
-        <version.org.jboss.jboss-transaction-spi>7.6.1.Final</version.org.jboss.jboss-transaction-spi>
+        <version.org.jboss.jboss-transaction-spi>8.0.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.logging>3.4.2.Final</version.org.jboss.logging>
-        <version.org.jboss.narayana>5.12.5.Final</version.org.jboss.narayana>
+        <version.org.jboss.narayana>6.0.0.Final</version.org.jboss.narayana>
         <version.org.junit.jupiter>5.8.2</version.org.junit.jupiter>
         <version.org.junit.platform>1.8.2</version.org.junit.platform>
         <version.org.ops4j.pax.exam>4.13.5</version.org.ops4j.pax.exam>


### PR DESCRIPTION
We recently released Narayana 6.0.0.Final and jboss-transaction-spi 8.0.0.Final

These are the versions of the dependencies that natively support the Jakarta EE namspace.

Remark: I couldn't find any tests that validate these new versions so I could only test that they compile!

Release Notes for 6.0.0.Final: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310200&version=12400773
Release Notes for 6.0.0.CR1: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12310200&version=12398668
Tag: https://github.com/jbosstm/narayana/releases/tag/6.0.0.Final

Narayana Diff: https://github.com/jbosstm/narayana/compare/6.0.0.CR1...6.0.0.Final

SPI Diff: https://github.com/jbosstm/jboss-transaction-spi/compare/7.6.1.Final...8.0.0.Final