### PR TITLE
Restore autoconfiguration with SB3

### DIFF
--- a/agroal-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agroal-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.agroal.springframework.boot.AgroalDataSourceConfiguration


### PR DESCRIPTION
Autoconfiguration does not work OOB in SB3 since `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` has to be used instead of `spring.factories`