### PR TITLE
AG-219 - Optimize resource tracking

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
@@ -7,6 +7,7 @@ import io.agroal.api.cache.Acquirable;
 import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
 import io.agroal.api.transaction.TransactionAware;
+import io.agroal.pool.util.AutoCloseableElement;
 import io.agroal.pool.util.UncheckedArrayList;
 import io.agroal.pool.wrapper.ConnectionWrapper;
 
@@ -16,10 +17,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.time.Duration;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
@@ -57,7 +56,7 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
     private final Set<DirtyAttribute> dirtyAttributes = noneOf( DirtyAttribute.class );
 
     // collection of wrappers created while enlisted in the current transaction
-    private final Collection<ConnectionWrapper> enlistedOpenWrappers = new CopyOnWriteArrayList<>();
+    private final AutoCloseableElement enlistedOpenWrappers = AutoCloseableElement.newHead();
 
     // Can use annotation to get (in theory) a little better performance
     // @Contended
@@ -96,11 +95,7 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
     }
 
     public ConnectionWrapper connectionWrapper() {
-        ConnectionWrapper wrapper = new ConnectionWrapper( this, connectionPool.getConfiguration().connectionFactoryConfiguration().trackJdbcResources() );
-        if ( enlisted ) {
-            enlistedOpenWrappers.add( wrapper );
-        }
-        return wrapper;
+        return new ConnectionWrapper( this, connectionPool.getConfiguration().connectionFactoryConfiguration().trackJdbcResources(), enlisted ? enlistedOpenWrappers : null );
     }
 
     public ConnectionWrapper detachedWrapper() {
@@ -112,9 +107,7 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
         if ( leakReport.hasLeak() ) {
             fireOnWarning( connectionPool.getListeners(), "JDBC resources leaked: " + leakReport.resultSetCount() + " ResultSet(s) and " + leakReport.statementCount() + " Statement(s)" );
         }
-        if ( enlisted ) {
-            enlistedOpenWrappers.remove( wrapper );
-        } else if ( !wrapper.isDetached() ) {
+        if ( !enlisted && !wrapper.isDetached() ) {
             transactionEnd();
         }
     }
@@ -316,7 +309,7 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
     public Connection getConnection() {
         return detachedWrapper();
     }
-    
+
     @Override
     public void transactionStart() throws SQLException {
         try {
@@ -333,19 +326,12 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
 
     @Override
     public void transactionBeforeCompletion(boolean successful) {
-        if ( !enlistedOpenWrappers.isEmpty() ) {
-            for ( ConnectionWrapper wrapper : enlistedOpenWrappers ) {
-                if ( successful ) {
-                    fireOnWarning( connectionPool.getListeners(), "Closing open connection prior to commit" );
-                } else {
-                    // AG-168 - Close without warning as Synchronization.beforeCompletion is only invoked on success. See issue for more details.
-                    // fireOnWarning( connectionPool.getListeners(), "Closing open connection prior to rollback" );
-                }
-                try {
-                    wrapper.close();
-                } catch ( SQLException e ) {
-                    // never occurs
-                }
+        if ( enlistedOpenWrappers.closeAllAutocloseableElements() != 0 ) {
+            if ( successful ) {
+                fireOnWarning( connectionPool.getListeners(), "Closing open connection(s) prior to commit" );
+            } else {
+                // AG-168 - Close without warning as Synchronization.beforeCompletion is only invoked on success. See issue for more details.
+                // fireOnWarning( connectionPool.getListeners(), "Closing open connection prior to rollback" );
             }
         }
     }
@@ -374,12 +360,9 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
 
     @Override
     public void transactionEnd() throws SQLException {
-        if ( !enlistedOpenWrappers.isEmpty() ) {
-            for ( ConnectionWrapper wrapper : enlistedOpenWrappers ) {
-                // should never happen, but it's here as a safeguard to prevent double returns in all cases.
-                fireOnWarning( connectionPool.getListeners(), "Closing open connection after completion" );
-                wrapper.close();
-            }
+        if ( enlistedOpenWrappers.closeAllAutocloseableElements() != 0 ) {
+            // should never happen, but it's here as a safeguard to prevent double returns in all cases.
+            fireOnWarning( connectionPool.getListeners(), "Closing open connection(s) on after completion" );
         }
         enlisted = false;
         connectionPool.returnConnectionHandler( this );

--- a/agroal-pool/src/main/java/io/agroal/pool/util/AutoCloseableElement.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/util/AutoCloseableElement.java
@@ -1,0 +1,99 @@
+// Copyright (C) 2023 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.pool.util;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+/**
+ * Abstract class to track auto-closeable resources by having them forming a collection between themselves.
+ * This class is designed to prevent leaks of Agroal JDBC wrapper objects.
+ * Once a new wrapper is created it tries to insert itself between the head and the first element of the list (if it exists).
+ * There is the invariant that at any given point in time the list can be traversed from the head and all inserted elements are reachable.
+ * As an implementation detail, the collection formed is actually a stack (FILO behaviour) and is thread-safe.
+ * <p>
+ * The resources do not remove themselves on close. It's assumed that the implementations of this interface are wrappers and the contents are dropped at that moment.
+ * Also, allowing removal of elements would introduce an undesirable amount of complexity to this class.
+ *
+ * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
+ */
+public abstract class AutoCloseableElement implements AutoCloseable {
+
+    private static final AtomicReferenceFieldUpdater<AutoCloseableElement, AutoCloseableElement> NEXT_UPDATER = newUpdater( AutoCloseableElement.class, AutoCloseableElement.class, "nextElement" );
+
+    private volatile AutoCloseableElement nextElement;
+
+    public abstract boolean isClosed() throws Exception;
+
+    @SuppressWarnings( "ThisEscapedInObjectConstruction" )
+    protected AutoCloseableElement(AutoCloseableElement head) {
+        if ( head != null ) {
+            // point to the first element of the list and attempt to have the head to point at us
+            do {
+                nextElement = head.getNextElement();
+            } while ( !head.setNextElement( nextElement, this ) );
+        }
+    }
+
+    /**
+     * Returns the number of resources that were not properly closed. The resources are closed in the process and the collection is cleared.
+     * This method should be invoked on the collection head only, otherwise it may not traverse the whole collection.
+     */
+    public int closeAllAutocloseableElements() {
+        int count = 0;
+        // if under contention, the call that succeeds to reset the head is the one and only that will traverse the whole collection
+        for ( AutoCloseableElement next = resetNextElement(); next != null; next = next.resetNextElement() ) {
+            try {
+                if ( !next.isClosed() ) {
+                    count++;
+                    next.close();
+                }
+            } catch ( Exception e ) {
+                // ignore
+            }
+        }
+        return count;
+    }
+
+    // --- convenience private methods to access the field updater //
+
+    private boolean setNextElement(AutoCloseableElement expected, AutoCloseableElement element) {
+        return NEXT_UPDATER.compareAndSet( this, expected, element );
+    }
+
+    private AutoCloseableElement getNextElement() {
+        return NEXT_UPDATER.get( this );
+    }
+
+    private AutoCloseableElement resetNextElement() {
+        return NEXT_UPDATER.getAndSet( this, null );
+    }
+
+    // --- head of the list //
+
+    /**
+     * Create a special marker element to be used as head of a collection.
+     */
+    public static AutoCloseableElement newHead() {
+        return new AutoCloseableElementHead();
+    }
+
+    private static class AutoCloseableElementHead extends AutoCloseableElement {
+
+        private AutoCloseableElementHead() {
+            super( null );
+        }
+
+        @Override
+        public boolean isClosed() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void close() throws Exception {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/CallableStatementWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/CallableStatementWrapper.java
@@ -3,6 +3,8 @@
 
 package io.agroal.pool.wrapper;
 
+import io.agroal.pool.util.AutoCloseableElement;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.lang.reflect.InvocationHandler;
@@ -60,8 +62,8 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
 
     private CallableStatement wrappedStatement;
 
-    public CallableStatementWrapper(ConnectionWrapper connectionWrapper, CallableStatement statement, boolean trackJdbcResources) {
-        super( connectionWrapper, statement, trackJdbcResources );
+    public CallableStatementWrapper(ConnectionWrapper connectionWrapper, CallableStatement statement, boolean trackJdbcResources, AutoCloseableElement head) {
+        super( connectionWrapper, statement, trackJdbcResources, head );
         wrappedStatement = statement;
     }
 

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/PreparedStatementWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/PreparedStatementWrapper.java
@@ -3,6 +3,8 @@
 
 package io.agroal.pool.wrapper;
 
+import io.agroal.pool.util.AutoCloseableElement;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.lang.reflect.InvocationHandler;
@@ -59,8 +61,8 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
 
     private PreparedStatement wrappedStatement;
 
-    public PreparedStatementWrapper(ConnectionWrapper connectionWrapper, PreparedStatement statement, boolean trackJdbcResources) {
-        super( connectionWrapper, statement, trackJdbcResources );
+    public PreparedStatementWrapper(ConnectionWrapper connectionWrapper, PreparedStatement statement, boolean trackJdbcResources, AutoCloseableElement head) {
+        super( connectionWrapper, statement, trackJdbcResources, head );
         wrappedStatement = statement;
     }
 

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/ResultSetWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/ResultSetWrapper.java
@@ -3,6 +3,8 @@
 
 package io.agroal.pool.wrapper;
 
+import io.agroal.pool.util.AutoCloseableElement;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.lang.reflect.InvocationHandler;
@@ -34,7 +36,7 @@ import static java.lang.reflect.Proxy.newProxyInstance;
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
  * @author <a href="jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
-public final class ResultSetWrapper implements ResultSet {
+public final class ResultSetWrapper extends AutoCloseableElement implements ResultSet {
 
     static final String CLOSED_RESULT_SET_STRING = ResultSetWrapper.class.getSimpleName() + ".CLOSED_RESULT_SET";
 
@@ -62,7 +64,8 @@ public final class ResultSetWrapper implements ResultSet {
 
     private ResultSet wrappedResultSet;
 
-    public ResultSetWrapper(StatementWrapper statementWrapper, ResultSet resultSet) {
+    public ResultSetWrapper(StatementWrapper statementWrapper, ResultSet resultSet, AutoCloseableElement head) {
+        super( head );
         statement = statementWrapper;
         wrappedResultSet = resultSet;
     }
@@ -75,7 +78,6 @@ public final class ResultSetWrapper implements ResultSet {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
         } finally {
-            statement.releaseTrackedResultSet( this );
             wrappedResultSet = CLOSED_RESULT_SET;
         }
     }

--- a/agroal-test/src/test/java/io/agroal/test/basic/ConnectionCloseTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/ConnectionCloseTests.java
@@ -134,7 +134,7 @@ public class ConnectionCloseTests {
 
     @Test
     @DisplayName( "Flush on close" )
-    void flushOnCloseTest() throws SQLException, InterruptedException {
+    void flushOnCloseTest() throws Exception {
         OnWarningListener warningListener = new OnWarningListener();
         OnDestroyListener destroyListener = new OnDestroyListener( 1 );
 
@@ -169,7 +169,6 @@ public class ConnectionCloseTests {
 
     @Test
     @DisplayName( "ResultSet leak" )
-    @SuppressWarnings( "JDBCResourceOpenedButNotSafelyClosed" )
     void resultSetLeak() throws SQLException {
         ResultSet resultSet;
         OnWarningListener listener = new OnWarningListener();
@@ -177,6 +176,7 @@ public class ConnectionCloseTests {
             try ( Connection connection = dataSource.getConnection() ) {
                 Statement statement = connection.createStatement();
                 resultSet = statement.getResultSet();
+                statement.close();
             }
         }
         assertTrue( resultSet.isClosed(), "Leaked ResultSet not closed" );


### PR DESCRIPTION
Get rid of collections that are currently used to track JDBC resources (`Connection`, `Statement`, `ResultSet`) and instead have the wrapper objects that Agroal uses to track the resources form a collection between themselves.

This is implemented by having the wrapper extend the `AutoCloseableElement` class that implements the list (actually, it has stack behavior - FILO). There is also a special extension of the class used as head of the list. Once a new wrapper is created it tries to insert itself between the head and the first element of the list (if it exists). There is the invariant that at any given point in time the list can be traversed from the head and all wrappers are reachable.

Unlike before, the wrappers do not remove themselves during operation. They are dropped just at the moments when the list is cleared. This is not a big deal as the wrapped JDBC resources are still dropped on calls to the `close()` method.