### PR TITLE
AG-223: autoconfigurations and orders

### DIFF
--- a/agroal-spring-boot-starter/pom.xml
+++ b/agroal-spring-boot-starter/pom.xml
@@ -36,12 +36,18 @@
             <artifactId>spring-tx</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- Actuator -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Micrometer -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>${version.io.micrometer}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <!-- SLF4J -->
         <dependency>

--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSourceConfiguration.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSourceConfiguration.java
@@ -13,13 +13,15 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.jta.JtaTransactionManager;
 import org.springframework.util.StringUtils;
 
@@ -30,10 +32,11 @@ import static org.springframework.boot.jdbc.DatabaseDriver.fromJdbcUrl;
 /**
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
  */
-@Configuration( proxyBeanMethods = false )
+@AutoConfiguration(before = DataSourceAutoConfiguration.class)
 @ConditionalOnClass( AgroalDataSource.class )
 @ConditionalOnMissingBean( DataSource.class )
 @ConditionalOnProperty( name = "spring.datasource.type", havingValue = "io.agroal.springframework.boot.AgroalDataSource", matchIfMissing = true )
+@EnableConfigurationProperties(DataSourceProperties.class)
 public class AgroalDataSourceConfiguration {
 
     private final Logger logger = LoggerFactory.getLogger( AgroalDataSourceConfiguration.class );

--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSourceConfiguration.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSourceConfiguration.java
@@ -7,6 +7,7 @@ import io.agroal.narayana.NarayanaTransactionIntegration;
 import io.agroal.springframework.boot.jndi.AgroalDataSourceJndiBinder;
 import io.agroal.springframework.boot.jndi.DefaultAgroalDataSourceJndiBinder;
 
+import io.agroal.springframework.boot.metrics.AgroalPoolDataSourceMetadataProviderConfiguration;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +23,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.jta.JtaTransactionManager;
 import org.springframework.util.StringUtils;
 
@@ -37,6 +39,7 @@ import static org.springframework.boot.jdbc.DatabaseDriver.fromJdbcUrl;
 @ConditionalOnMissingBean( DataSource.class )
 @ConditionalOnProperty( name = "spring.datasource.type", havingValue = "io.agroal.springframework.boot.AgroalDataSource", matchIfMissing = true )
 @EnableConfigurationProperties(DataSourceProperties.class)
+@Import(AgroalPoolDataSourceMetadataProviderConfiguration.class)
 public class AgroalDataSourceConfiguration {
 
     private final Logger logger = LoggerFactory.getLogger( AgroalDataSourceConfiguration.class );

--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/metrics/AgroalDataSourcePoolMetricsAutoConfiguration.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/metrics/AgroalDataSourcePoolMetricsAutoConfiguration.java
@@ -5,20 +5,20 @@ package io.agroal.springframework.boot.metrics;
 
 import io.agroal.api.AgroalDataSource;
 import io.agroal.pool.DefaultMetricsRepository;
+import io.agroal.springframework.boot.AgroalDataSourceConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.jdbc.DataSourceUnwrapper;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-import java.util.Map;
 
 import javax.sql.DataSource;
+import java.util.Map;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration(after = {AgroalDataSourceConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @ConditionalOnClass({AgroalDataSource.class, MeterRegistry.class})
 @ConditionalOnBean({AgroalDataSource.class, MeterRegistry.class})
 public class AgroalDataSourcePoolMetricsAutoConfiguration {

--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/metrics/AgroalPoolDataSourceMetadataProviderConfiguration.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/metrics/AgroalPoolDataSourceMetadataProviderConfiguration.java
@@ -4,14 +4,12 @@
 package io.agroal.springframework.boot.metrics;
 
 import io.agroal.api.AgroalDataSource;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.jdbc.DataSourceUnwrapper;
 import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass(AgroalDataSource.class)
 public class AgroalPoolDataSourceMetadataProviderConfiguration {
 
     @Bean

--- a/agroal-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agroal-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,2 @@
 io.agroal.springframework.boot.AgroalDataSourceConfiguration
-io.agroal.springframework.boot.metrics.AgroalPoolDataSourceMetadataProviderConfiguration
 io.agroal.springframework.boot.metrics.AgroalDataSourcePoolMetricsAutoConfiguration

--- a/agroal-test/pom.xml
+++ b/agroal-test/pom.xml
@@ -153,6 +153,24 @@
             <version>${version.com.h2database}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+            <version>${version.org.springframework.boot}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${version.io.micrometer}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${version.io.micrometer}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/agroal-test/src/test/java/io/agroal/test/springframework/AgroalDataSourceConfigurationTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/springframework/AgroalDataSourceConfigurationTests.java
@@ -2,13 +2,21 @@ package io.agroal.test.springframework;
 
 import io.agroal.springframework.boot.AgroalDataSource;
 import io.agroal.springframework.boot.AgroalDataSourceConfiguration;
+import io.agroal.springframework.boot.metrics.AgroalDataSourcePoolMetadata;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadata;
+import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import javax.sql.DataSource;
+
+import java.util.Map;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -25,7 +33,19 @@ class AgroalDataSourceConfigurationTests {
     @DisplayName("Autoconfigurations will trigger in the correct order and the beans will be registered and created")
     @Test
     void testAutoconfigureAgroalDataSource() {
-        runner.run(context -> assertThat(context).hasSingleBean(AgroalDataSource.class));
+        runner.run(context -> {
+            assertThat(context).hasSingleBean(AgroalDataSource.class);
+
+            DataSource dataSource = context.getBean(AgroalDataSource.class);
+            Map<String, DataSourcePoolMetadataProvider> metadataProviders = context.getBeansOfType(DataSourcePoolMetadataProvider.class);
+
+            DataSourcePoolMetadata metadata = metadataProviders.values().stream()
+                    .map(provider -> provider.getDataSourcePoolMetadata(dataSource))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("AgroalDataSourcePoolMetaData not provided by any DataSourcePoolMetaDataProvider"));
+            assertThat(metadata).isInstanceOf(AgroalDataSourcePoolMetadata.class);
+        });
     }
 
     @DisplayName("Autoconfiguration will not trigger when AgroalDataSource is not on the classpath")

--- a/agroal-test/src/test/java/io/agroal/test/springframework/AgroalDataSourceConfigurationTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/springframework/AgroalDataSourceConfigurationTests.java
@@ -1,0 +1,52 @@
+package io.agroal.test.springframework;
+
+import io.agroal.springframework.boot.AgroalDataSource;
+import io.agroal.springframework.boot.AgroalDataSourceConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AgroalDataSourceConfigurationTests {
+    private final Class<?>[] autoconfigurationsInWrongOrder = new Class<?>[]{
+            DataSourceAutoConfiguration.class,
+            AgroalDataSourceConfiguration.class
+    };
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(autoconfigurationsInWrongOrder));
+
+    @DisplayName("Autoconfigurations will trigger in the correct order and the beans will be registered and created")
+    @Test
+    void testAutoconfigureAgroalDataSource() {
+        runner.run(context -> assertThat(context).hasSingleBean(AgroalDataSource.class));
+    }
+
+    @DisplayName("Autoconfiguration will not trigger when AgroalDataSource is not on the classpath")
+    @Test
+    void testAutoconfigureAgroalDataSourceNotPresentOnClasspath() {
+        runner
+                .withClassLoader(new FilteredClassLoader(AgroalDataSource.class))
+                .run(context -> assertThat(context).doesNotHaveBean(AgroalDataSourceConfiguration.class));
+    }
+
+    @DisplayName("The context will not start due to a cycle when forcing the wrong order of autoconfigurations")
+    @Test
+    void testAutoconfigurationWithCycle() {
+        assertThatThrownBy(
+                () -> runner.withConfiguration(AutoConfigurations.of(WrongOrderForcingAutoConfiguration.class)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("AutoConfigure cycle detected");
+    }
+
+    @AutoConfiguration(after = DataSourceAutoConfiguration.class, before = AgroalDataSourceConfiguration.class)
+    private static class WrongOrderForcingAutoConfiguration {
+
+    }
+}

--- a/agroal-test/src/test/java/io/agroal/test/springframework/metrics/AgroalDataSourcePoolMetricsAutoConfigurationTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/springframework/metrics/AgroalDataSourcePoolMetricsAutoConfigurationTests.java
@@ -1,0 +1,79 @@
+package io.agroal.test.springframework.metrics;
+
+import io.agroal.springframework.boot.AgroalDataSource;
+import io.agroal.springframework.boot.AgroalDataSourceConfiguration;
+import io.agroal.springframework.boot.metrics.AgroalDataSourcePoolMetricsAutoConfiguration;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AgroalDataSourcePoolMetricsAutoConfigurationTests {
+
+    private final Class<?>[] autoconfigurationsInWrongOrder = new Class<?>[]{
+            AgroalDataSourcePoolMetricsAutoConfiguration.class,
+            AgroalDataSourceConfiguration.class,
+            CompositeMeterRegistryAutoConfiguration.class,
+            SimpleMetricsExportAutoConfiguration.class,
+            MetricsAutoConfiguration.class
+    };
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(autoconfigurationsInWrongOrder));
+
+    @DisplayName("Autoconfigurations will trigger in the correct order and the beans will be registered and created")
+    @Test
+    void testAutoconfigureAgroalDataSourceMeterBinder() {
+        runner
+                .run(context -> {
+                    assertThat(context).hasSingleBean(MeterBinder.class);
+                    assertThat(context).hasSingleBean(AgroalDataSource.class);
+
+                    MeterBinder meterBinder = context.getBean(MeterBinder.class);
+                    AgroalDataSource dataSource = context.getBean(AgroalDataSource.class);
+
+                    assertThat(meterBinder).hasFieldOrPropertyWithValue("dataSources", Map.of("dataSource", dataSource));
+                });
+    }
+
+    @DisplayName("AgroalDataSourcePoolMetricsAutoConfiguration will not trigger without micrometer on the classpath")
+    @Test
+    void testMicrometerNotPresentOnClasspath() {
+        runner
+                .withClassLoader(new FilteredClassLoader(MeterRegistry.class))
+                .run(context -> assertThat(context).doesNotHaveBean(AgroalDataSourcePoolMetricsAutoConfiguration.class));
+    }
+
+    @DisplayName("The context will not start due to a cycle when forcing the wrong order of autoconfigurations")
+    @Test
+    void testAutoconfigurationWithCycle() {
+        assertThatThrownBy(
+                () -> runner.withConfiguration(AutoConfigurations.of(WrongOrderForcingAutoConfiguration.class)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("AutoConfigure cycle detected");
+    }
+
+    @AutoConfiguration(
+            after = AgroalDataSourcePoolMetricsAutoConfiguration.class,
+            before = {
+                    AgroalDataSourceConfiguration.class,
+                    MetricsAutoConfiguration.class,
+                    SimpleMetricsExportAutoConfiguration.class,
+                    CompositeMeterRegistryAutoConfiguration.class
+            })
+    private static class WrongOrderForcingAutoConfiguration {
+
+    }
+}


### PR DESCRIPTION
The autoconfigurations have been changed to ue the @AutoConfiguration annotation and also use explicit befores and afters. This ensures that agroal-spring-boot-starter's autoconfigurations are being triggered in the correct order in relation to spring boot's autoconfigurations.

Specifically, AgroalDataSourceConfiguration is going before DataSourceAutoConfiguration, so that spring boot does not create a DataSource because a DataSource bean is missing when AgroalDataSourceConfiguration also creates a DataSource when a DataSource bean is missing, making it a race condition. AgroalDataSourcePoolMetricsAutoConfiguration in turn will go after AgroalDataSourceConfiguration, because it is conditional on an AgroalDataSource bean being registered. AgoralDataSourcePoolMetricsAutoConfiguration will also trigger after CompositeMeterRegistryAutoConfiguration which seems to be the last autoconfiguration in spring boot actuator to register a MeterRegistry bean. While more libraries may actually create MeterRegistry beans, spring boot actuator is a known provider of MeterRegistry beans. Other libraries may very well register their MeterRegistry beans explicitly before spring boot actuator's CompositeMeterRegistryAutoConfiguration triggers. This seems to make CompositeMeterRegistryAutoConfiguration a good known candidate to autoconfige 'after'.

It seems like AgroalPoolDataSourceMetadataProviderConfiguration should remain a 'normal' @Configuration that needs to be imported by AgroalDataSourceConfiguration, just like in spring boot DataSourcePoolMetadataProvidersConfiguration is being imported by DataSourceAutoConfiguration.