### PR TITLE
AG-226: Added a fix/'hack' in order to set the timer to a resolution of 1 ms for Windows, so that the BasicConcurrencyTests can succeed on Windows.

### DIFF
--- a/agroal-test/src/test/java/io/agroal/test/basic/BasicConcurrencyTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/BasicConcurrencyTests.java
@@ -53,6 +53,7 @@ public class BasicConcurrencyTests {
     @BeforeAll
     static void setup() {
         registerMockDriver();
+        Utils.windowsTimerHack();
     }
 
     @AfterAll

--- a/agroal-test/src/test/java/io/agroal/test/basic/BasicConcurrencyTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/BasicConcurrencyTests.java
@@ -69,7 +69,7 @@ public class BasicConcurrencyTests {
     @DisplayName( "Multiple threads" )
     @SuppressWarnings( "ObjectAllocationInLoop" )
     void basicConnectionAcquireTest() throws SQLException {
-        int MAX_POOL_SIZE = 10, THREAD_POOL_SIZE = 32, CALLS = 50000, SLEEP_TIME = 1;
+        int MAX_POOL_SIZE = 10, THREAD_POOL_SIZE = 32, CALLS = 50000, SLEEP_TIME = 1, OVERHEAD = 1;
 
         ExecutorService executor = newFixedThreadPool( THREAD_POOL_SIZE );
         CountDownLatch latch = new CountDownLatch( CALLS );
@@ -99,7 +99,7 @@ public class BasicConcurrencyTests {
             }
 
             try {
-                long waitTime = (long) ( SLEEP_TIME * CALLS * 1.5 / MAX_POOL_SIZE );
+                long waitTime = ( SLEEP_TIME + OVERHEAD ) * CALLS / MAX_POOL_SIZE;
                 logger.info( format( "Main thread waiting for {0}ms", waitTime ) );
                 if ( !latch.await( waitTime, MILLISECONDS ) ) {
                     fail( "Did not execute within the required amount of time" );

--- a/agroal-test/src/test/java/io/agroal/test/basic/BasicConcurrencyTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/BasicConcurrencyTests.java
@@ -53,7 +53,9 @@ public class BasicConcurrencyTests {
     @BeforeAll
     static void setup() {
         registerMockDriver();
-        Utils.windowsTimerHack();
+        if (Utils.isWindowsOS()) {
+            Utils.windowsTimerHack();
+        }
     }
 
     @AfterAll

--- a/agroal-test/src/test/java/io/agroal/test/basic/Utils.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/Utils.java
@@ -22,4 +22,8 @@ public abstract class Utils {
         t.setDaemon(true);
         t.start();
     }
+
+    public static boolean isWindowsOS() {
+        return System.getProperty("os.name").startsWith("Windows");
+    }
 }

--- a/agroal-test/src/test/java/io/agroal/test/basic/Utils.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/Utils.java
@@ -1,3 +1,6 @@
+// Copyright (C) 2023 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
 package io.agroal.test.basic;
 
 public abstract class Utils {

--- a/agroal-test/src/test/java/io/agroal/test/basic/Utils.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/Utils.java
@@ -1,0 +1,22 @@
+package io.agroal.test.basic;
+
+public abstract class Utils {
+    /**
+     * This method will start a daemon thread that will sleep indefinitely in order to be able to park with a higher
+     * resolution for windows. Without this hack, LockSupport.parkNanos() will not be able to park for less than ~16ms
+     * on windows.
+     *
+     * @see <a href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking-part-ii-windows/">blog</a>
+     * @see <a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6435126">jdk bug</a>
+     */
+    public static void windowsTimerHack() {
+        Thread t = new Thread(() -> {
+            try {
+                Thread.sleep(Long.MAX_VALUE);
+            } catch (InterruptedException e) { // a delicious interrupt, omm, omm
+            }
+        });
+        t.setDaemon(true);
+        t.start();
+    }
+}


### PR DESCRIPTION
AG-226: Added a fix/'hack' in order to set the timer to a resolution of 1 ms for Windows, so that the BasicConcurrencyTests can succeed on Windows.