### PR TITLE
AG-234: Add getUrl() to AgroalDataSource

### DIFF
--- a/agroal-api/src/main/java/io/agroal/api/AgroalDataSource.java
+++ b/agroal-api/src/main/java/io/agroal/api/AgroalDataSource.java
@@ -57,6 +57,11 @@ public interface AgroalDataSource extends AutoCloseable, DataSource, Serializabl
     // --- //
 
     /**
+     * Allows access to the used jdbcUrl. DataSource derivation in spring boot's LiquibaseAutoConfiguration may need this.
+     */
+    String getUrl();
+
+    /**
      * Allows inspection of the configuration. Some properties allow read / write.
      */
     AgroalDataSourceConfiguration getConfiguration();

--- a/agroal-hikari/src/main/java/io/agroal/hikari/HikariUnderTheCovers.java
+++ b/agroal-hikari/src/main/java/io/agroal/hikari/HikariUnderTheCovers.java
@@ -107,6 +107,11 @@ public class HikariUnderTheCovers implements AgroalDataSource {
     }
 
     @Override
+    public String getUrl() {
+        return factoryConfiguration.jdbcUrl();
+    }
+
+    @Override
     public AgroalDataSourceConfiguration getConfiguration() {
         return configuration;
     }

--- a/agroal-pool/src/main/java/io/agroal/pool/DataSource.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/DataSource.java
@@ -55,6 +55,11 @@ public final class DataSource implements AgroalDataSource {
     }
 
     @Override
+    public String getUrl() {
+        return connectionPool.getConfiguration().connectionFactoryConfiguration().jdbcUrl();
+    }
+
+    @Override
     public AgroalDataSourceConfiguration getConfiguration() {
         return configuration;
     }

--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSource.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSource.java
@@ -56,6 +56,8 @@ public class AgroalDataSource implements io.agroal.api.AgroalDataSource, Initial
     private io.agroal.api.AgroalDataSource delegate;
     private String datasourceName = "<default>";
 
+    private String url;
+
     public AgroalDataSource() {
         datasourceConfiguration = new AgroalDataSourceConfigurationSupplier();
         connectionPoolConfiguration = new AgroalConnectionPoolConfigurationSupplier();
@@ -162,6 +164,12 @@ public class AgroalDataSource implements io.agroal.api.AgroalDataSource, Initial
 
     public void setUrl(String url) {
         connectionFactoryConfiguration.jdbcUrl( url );
+        this.url = url;
+    }
+
+    // AG-234 - LiquibaseAutoConfiguration in Spring Boot may need to derive from this DataSource using getUrl()
+    public String getUrl() {
+        return this.url;
     }
 
     public void setDriverClass(Class<? extends DataSource> driver) {
@@ -199,11 +207,11 @@ public class AgroalDataSource implements io.agroal.api.AgroalDataSource, Initial
     public void setRecoveryPassword(String password) {
         connectionFactoryConfiguration.recoveryCredential( new SimplePassword( password ) );
     }
-    
+
     public void setJdbcTransactionIsolation(int level) {
         connectionFactoryConfiguration.jdbcTransactionIsolation( level );
     }
-    
+
     public void setJdbcProperties(Map<String, String> properties) {
         properties.forEach(connectionFactoryConfiguration::jdbcProperty);
     }

--- a/agroal-test/pom.xml
+++ b/agroal-test/pom.xml
@@ -180,6 +180,12 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>4.23.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>dev.snowdrop</groupId>
             <artifactId>narayana-spring-boot-starter</artifactId>
             <version>${version.dev.snowdrop}</version>

--- a/agroal-test/src/test/java/io/agroal/test/springframework/LiquibaseTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/springframework/LiquibaseTests.java
@@ -1,0 +1,49 @@
+// Copyright (C) 2023 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.springframework;
+
+import io.agroal.springframework.boot.AgroalDataSourceConfiguration;
+import liquibase.integration.spring.SpringLiquibase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import javax.sql.DataSource;
+
+import static io.agroal.test.AgroalTestGroup.SPRING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag( SPRING )
+class LiquibaseTests {
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    AgroalDataSourceConfiguration.class,
+                    DataSourceAutoConfiguration.class,
+                    LiquibaseAutoConfiguration.class
+            ));
+
+    @DisplayName("Liquibase will work when separate credentials are provided for liquibase")
+    @Test
+    void testAutoconfigureLiquibaseUsingCustomCredentials() {
+        runner.withPropertyValues(
+                "spring.liquibase.user=liquibaseuser",
+                        "spring.liquibase.password=liquibasepassword",
+                        "spring.liquibase.driver-class-name=org.h2.Driver")
+                .run(context -> {
+            assertThat(context).hasSingleBean(SpringLiquibase.class);
+            DataSource primaryDataSource = context.getBean(DataSource.class);
+            DataSource liquibaseDataSource = context.getBean(SpringLiquibase.class).getDataSource();
+
+            assertThat(liquibaseDataSource)
+                    .isNotSameAs(primaryDataSource)
+                    .hasFieldOrPropertyWithValue("username", "liquibaseuser")
+                    .hasFieldOrPropertyWithValue("password", "liquibasepassword");
+
+        });
+    }
+}

--- a/agroal-test/src/test/resources/db/changelog/db.changelog-master.yaml
+++ b/agroal-test/src/test/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0
+      author: Ronald Mik


### PR DESCRIPTION
AG-234: Add getUrl() to AgroalDataSource to expose the url used in order for liquibase to be able to derive a DataSource from an existing DataSource.