### PR TITLE
AG-237: Ability to change DataSource settings after starting

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/util/ReloadDataSourceUtil.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/util/ReloadDataSourceUtil.java
@@ -1,0 +1,52 @@
+package io.agroal.pool.util;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
+import io.agroal.api.configuration.supplier.AgroalConnectionPoolConfigurationSupplier;
+import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
+import io.agroal.api.security.NamePrincipal;
+import io.agroal.api.security.SimplePassword;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+public class ReloadDataSourceUtil {
+    public static final String AGROAL_JDBC_URL = "agroal_jdbc_url";
+    public static final String AGROAL_USERNAME = "agroal_principal";
+    public static final String AGROAL_PASSWORD = "agroal_credential";
+
+    public static boolean checkConnectionWithNewCredentials(String url, String username, String password) {
+        AgroalDataSourceConfigurationSupplier dataSourceConfiguration = new AgroalDataSourceConfigurationSupplier();
+        AgroalConnectionPoolConfigurationSupplier poolConfiguration = dataSourceConfiguration.connectionPoolConfiguration();
+        AgroalConnectionFactoryConfigurationSupplier connectionFactoryConfiguration = poolConfiguration.connectionFactoryConfiguration();
+
+        poolConfiguration
+                .initialSize(1)
+                .maxSize(3)
+                .minSize(1)
+                .maxLifetime(Duration.of(5, ChronoUnit.MINUTES))
+                .acquisitionTimeout(Duration.of(30, ChronoUnit.SECONDS));
+
+        connectionFactoryConfiguration
+                .jdbcUrl(url)
+                .principal(new NamePrincipal(username))
+                .credential(new SimplePassword(password));
+
+        AgroalDataSource datasource = null;
+        try {
+            datasource = AgroalDataSource.from(dataSourceConfiguration.get());
+            if (datasource.isHealthy(true)) {
+                return true;
+            }
+            datasource.flush(AgroalDataSource.FlushMode.ALL);
+            return false;
+        } catch (Exception ex) {
+            return false;
+        } finally {
+            if (datasource != null) {
+                datasource.flush(AgroalDataSource.FlushMode.ALL);
+                datasource.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi, Agroal Community!

Quartus supports database management via Agroal Connection Pool (https://quarkus.io/guides/datasource).

When initializing an application, Quarkus allows you to create unremovable beans, for example DataSource. https://quarkus.io/guides/cdi-reference#remove_unused_beans

The existing library functionality does not allow you to restart the connection with new credentials in an existing bean. This functionality would be useful when switching to a backup database in case of an accident.

Can we add this functionality to the new version?

 Example:

        Properties properties = new Properties();
        properties.setProperty(ReloadDataSourceUtil.AGROAL_JDBC_URL, Configuration.getConfig().getConfigValue("kc.db-url").getValue());
        properties.setProperty(ReloadDataSourceUtil.AGROAL_USERNAME, Configuration.getConfig().getConfigValue("kc.db-username").getValue());
        properties.setProperty(ReloadDataSourceUtil.AGROAL_PASSWORD, Configuration.getConfig().getConfigValue("kc.db-password").getValue());

        io.agroal.pool.DataSource dataSource = (io.agroal.pool.DataSource) Arc.container().instance(AgroalDataSource.class).get();
        dataSource.reloadDataSourceWithNewCredentials(properties, AgroalDataSource.FlushMode.ALL);  