### PR TITLE
AG-241 - Switch from property injection to constructor injection

### DIFF
--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSourceAutoConfiguration.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSourceAutoConfiguration.java
@@ -33,23 +33,25 @@ import static org.springframework.util.StringUtils.hasLength;
 /**
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
  */
-@AutoConfiguration(before = DataSourceAutoConfiguration.class)
+@AutoConfiguration( before = DataSourceAutoConfiguration.class )
 @ConditionalOnClass( AgroalDataSource.class )
 @ConditionalOnMissingBean( DataSource.class )
 @ConditionalOnProperty( name = "spring.datasource.type", havingValue = "io.agroal.springframework.boot.AgroalDataSource", matchIfMissing = true )
-@EnableConfigurationProperties(DataSourceProperties.class)
-@Import(AgroalPoolDataSourceMetadataProviderConfiguration.class)
-public class AgroalDataSourceConfiguration {
+@EnableConfigurationProperties( DataSourceProperties.class )
+@Import( AgroalPoolDataSourceMetadataProviderConfiguration.class )
+public class AgroalDataSourceAutoConfiguration {
 
-    private final Logger logger = LoggerFactory.getLogger( AgroalDataSourceConfiguration.class );
+    private final Logger logger = LoggerFactory.getLogger( AgroalDataSourceAutoConfiguration.class );
 
-    @Autowired( required = false )
-    @SuppressWarnings( "WeakerAccess" )
-    public JtaTransactionManager jtaPlatform;
+    private final JtaTransactionManager jtaPlatform;
+    private final XAResourceRecoveryRegistry recoveryRegistry;
 
-    @Autowired( required = false )
-    @SuppressWarnings( "WeakerAccess" )
-    public XAResourceRecoveryRegistry recoveryRegistry;
+    public AgroalDataSourceAutoConfiguration(
+            @Autowired( required = false ) JtaTransactionManager jtaPlatform,
+            @Autowired( required = false ) XAResourceRecoveryRegistry recoveryRegistry ) {
+        this.jtaPlatform = jtaPlatform;
+        this.recoveryRegistry = recoveryRegistry;
+    }
 
     @Bean
     @ConfigurationProperties( prefix = "spring.datasource.agroal" )
@@ -58,7 +60,7 @@ public class AgroalDataSourceConfiguration {
             DataSourceProperties properties,
             @Value( "${spring.datasource.agroal.connectable:false}" ) boolean connectable,
             @Value( "${spring.datasource.agroal.firstResource:false}" ) boolean firstResource,
-            ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder) {
+            ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder ) {
 
         AgroalDataSource dataSource = properties.initializeDataSourceBuilder().type( AgroalDataSource.class ).build();
         if ( !hasLength( properties.getDriverClassName() ) ) {

--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/metrics/AgroalDataSourcePoolMetricsAutoConfiguration.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/metrics/AgroalDataSourcePoolMetricsAutoConfiguration.java
@@ -5,9 +5,10 @@ package io.agroal.springframework.boot.metrics;
 
 import io.agroal.api.AgroalDataSource;
 import io.agroal.pool.DefaultMetricsRepository;
-import io.agroal.springframework.boot.AgroalDataSourceConfiguration;
+import io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -16,9 +17,10 @@ import org.springframework.boot.jdbc.DataSourceUnwrapper;
 import org.springframework.context.annotation.Bean;
 
 import javax.sql.DataSource;
+
 import java.util.Map;
 
-@AutoConfiguration(after = {AgroalDataSourceConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
+@AutoConfiguration(after = {AgroalDataSourceAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @ConditionalOnClass({AgroalDataSource.class, MeterRegistry.class})
 @ConditionalOnBean({AgroalDataSource.class, MeterRegistry.class})
 public class AgroalDataSourcePoolMetricsAutoConfiguration {

--- a/agroal-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agroal-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,2 @@
-io.agroal.springframework.boot.AgroalDataSourceConfiguration
+io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration
 io.agroal.springframework.boot.metrics.AgroalDataSourcePoolMetricsAutoConfiguration

--- a/agroal-test/src/test/java/io/agroal/test/springframework/AgroalDataSourceConfigurationTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/springframework/AgroalDataSourceConfigurationTests.java
@@ -8,7 +8,7 @@ import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
 import io.agroal.api.transaction.TransactionIntegration;
 import io.agroal.narayana.NarayanaTransactionIntegration;
 import io.agroal.springframework.boot.AgroalDataSource;
-import io.agroal.springframework.boot.AgroalDataSourceConfiguration;
+import io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration;
 import io.agroal.springframework.boot.metrics.AgroalDataSourcePoolMetadata;
 import io.agroal.test.MockConnection;
 import io.agroal.test.MockDriver;
@@ -54,7 +54,7 @@ class AgroalDataSourceConfigurationTests {
 
     private final Class<?>[] autoconfigurationsInWrongOrder = new Class<?>[]{
             DataSourceAutoConfiguration.class,
-            AgroalDataSourceConfiguration.class
+            AgroalDataSourceAutoConfiguration.class
     };
 
     private final ApplicationContextRunner runner = new ApplicationContextRunner()
@@ -225,7 +225,7 @@ class AgroalDataSourceConfigurationTests {
     void testAutoconfigureAgroalDataSourceNotPresentOnClasspath() {
         runner
                 .withClassLoader(new FilteredClassLoader(AgroalDataSource.class))
-                .run(context -> assertThat(context).doesNotHaveBean(AgroalDataSourceConfiguration.class));
+                .run(context -> assertThat(context).doesNotHaveBean(AgroalDataSourceAutoConfiguration.class));
     }
 
     @DisplayName("The context will not start due to a cycle when forcing the wrong order of autoconfigurations")
@@ -237,7 +237,7 @@ class AgroalDataSourceConfigurationTests {
                 .hasMessageContaining("AutoConfigure cycle detected");
     }
 
-    @AutoConfiguration(after = DataSourceAutoConfiguration.class, before = AgroalDataSourceConfiguration.class)
+    @AutoConfiguration(after = DataSourceAutoConfiguration.class, before = AgroalDataSourceAutoConfiguration.class)
     private static class WrongOrderForcingAutoConfiguration {
 
     }

--- a/agroal-test/src/test/java/io/agroal/test/springframework/LiquibaseTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/springframework/LiquibaseTests.java
@@ -3,7 +3,7 @@
 
 package io.agroal.test.springframework;
 
-import io.agroal.springframework.boot.AgroalDataSourceConfiguration;
+import io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration;
 import liquibase.integration.spring.SpringLiquibase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class LiquibaseTests {
     private final ApplicationContextRunner runner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(
-                    AgroalDataSourceConfiguration.class,
+                    AgroalDataSourceAutoConfiguration.class,
                     DataSourceAutoConfiguration.class,
                     LiquibaseAutoConfiguration.class
             ));

--- a/agroal-test/src/test/java/io/agroal/test/springframework/metrics/AgroalDataSourcePoolMetricsAutoConfigurationTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/springframework/metrics/AgroalDataSourcePoolMetricsAutoConfigurationTests.java
@@ -4,7 +4,7 @@
 package io.agroal.test.springframework.metrics;
 
 import io.agroal.springframework.boot.AgroalDataSource;
-import io.agroal.springframework.boot.AgroalDataSourceConfiguration;
+import io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration;
 import io.agroal.springframework.boot.metrics.AgroalDataSourcePoolMetricsAutoConfiguration;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -36,7 +36,7 @@ class AgroalDataSourcePoolMetricsAutoConfigurationTests {
 
     private final Class<?>[] autoconfigurationsInWrongOrder = new Class<?>[]{
             AgroalDataSourcePoolMetricsAutoConfiguration.class,
-            AgroalDataSourceConfiguration.class,
+            AgroalDataSourceAutoConfiguration.class,
             CompositeMeterRegistryAutoConfiguration.class,
             SimpleMetricsExportAutoConfiguration.class,
             MetricsAutoConfiguration.class
@@ -88,7 +88,7 @@ class AgroalDataSourcePoolMetricsAutoConfigurationTests {
     @AutoConfiguration(
             after = AgroalDataSourcePoolMetricsAutoConfiguration.class,
             before = {
-                    AgroalDataSourceConfiguration.class,
+                    AgroalDataSourceAutoConfiguration.class,
                     MetricsAutoConfiguration.class,
                     SimpleMetricsExportAutoConfiguration.class,
                     CompositeMeterRegistryAutoConfiguration.class


### PR DESCRIPTION
Hi @barreiro, I'm actually working on a poc for a multiple dataSource SpringBoot application. It would be nice to have the property injection in AgroalDataSourceConfiguration to be switched to constructor injection. Make it a bit nicer to use. If okay, I would open a JIRA issue case.

Btw, better name would be AgroalDataSourceAutoConfiguration. Rename as well?