### PR TITLE
Spring Boot Starter: enable setting of security provider and credentials

### DIFF
--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSource.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSource.java
@@ -13,6 +13,7 @@ import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfiguration
 import io.agroal.api.configuration.supplier.AgroalConnectionPoolConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalPropertiesReader;
+import io.agroal.api.security.AgroalSecurityProvider;
 import io.agroal.api.security.NamePrincipal;
 import io.agroal.api.security.SimplePassword;
 import io.agroal.api.transaction.TransactionIntegration;
@@ -190,6 +191,14 @@ public class AgroalDataSource implements io.agroal.api.AgroalDataSource, Initial
 
     public void setDriverClassName(String driver) {
         connectionFactoryConfiguration.connectionProviderClassName( driver );
+    }
+
+    public void addSecurityProvider(AgroalSecurityProvider securityProvider) {
+        connectionFactoryConfiguration.addSecurityProvider(securityProvider);
+    }
+
+    public void credential(Object credential) {
+        connectionFactoryConfiguration.credential( credential );
     }
 
     public void setUsername(String username) {


### PR DESCRIPTION
We are using vault for db password rotation. for this to work without restarting the application (which would break long running jobs) we need to be able to supply a suitable security provider with corresponding credentials when creating the data source. This is not possible at the moment. We would like to do something like this:
```
AgroalDataSource ds = dataSourceProperties().initializeDataSourceBuilder()
                                            .type(AgroalDataSource.class)
                                            .build();
ds.addSecurityProvider(vaultSecurityProvider);
ds.credential(vaultCredentials);
```
This pull request adds those methods.