### PR TITLE
AG-255 - Reset read-only state

### DIFF
--- a/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionFactoryConfiguration.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionFactoryConfiguration.java
@@ -24,6 +24,11 @@ public interface AgroalConnectionFactoryConfiguration {
     boolean autoCommit();
 
     /**
+     * If pooled connections are kept in read-only state, according to {@link java.sql.Connection#setReadOnly(boolean)}}. The JDBC driver is responsible for enforcing.
+     */
+    boolean readOnly();
+
+    /**
      * If JDBC resources ({@link java.sql.Statement} and {@link java.sql.ResultSet}) should be tracked to be closed if leaked.
      */
     boolean trackJdbcResources();

--- a/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalConnectionFactoryConfigurationSupplier.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalConnectionFactoryConfigurationSupplier.java
@@ -31,6 +31,7 @@ public class AgroalConnectionFactoryConfigurationSupplier implements Supplier<Ag
     private static final String PASSWORD_PROPERTY_NAME = "password";
 
     boolean autoCommit = true;
+    boolean readOnly;
     boolean trackJdbcResources = true;
     Duration loginTimeout = Duration.ZERO;
     String jdbcUrl = "";
@@ -60,6 +61,7 @@ public class AgroalConnectionFactoryConfigurationSupplier implements Supplier<Ag
             return;
         }
         autoCommit = existingConfiguration.autoCommit();
+        readOnly = existingConfiguration.readOnly();
         loginTimeout = existingConfiguration.loginTimeout();
         jdbcUrl = existingConfiguration.jdbcUrl();
         initialSql = existingConfiguration.initialSql();
@@ -90,6 +92,22 @@ public class AgroalConnectionFactoryConfigurationSupplier implements Supplier<Ag
     public AgroalConnectionFactoryConfigurationSupplier autoCommit(boolean autoCommitEnabled) {
         checkLock();
         autoCommit = autoCommitEnabled;
+        return this;
+    }
+
+    /**
+     * Sets the value of read-only for connections on the pool.
+     */
+    public AgroalConnectionFactoryConfigurationSupplier readOnly() {
+        return readOnly( true );
+    }
+
+    /**
+     * Sets the value of read-only for connections on the pool. Default is false.
+     */
+    public AgroalConnectionFactoryConfigurationSupplier readOnly(boolean readOnlyEnabled) {
+        checkLock();
+        readOnly = readOnlyEnabled;
         return this;
     }
 
@@ -276,6 +294,11 @@ public class AgroalConnectionFactoryConfigurationSupplier implements Supplier<Ag
             @Override
             public boolean autoCommit() {
                 return autoCommit;
+            }
+
+            @Override
+            public boolean readOnly() {
+                return readOnly;
             }
 
             @Override

--- a/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalPropertiesReader.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalPropertiesReader.java
@@ -101,6 +101,7 @@ public class AgroalPropertiesReader implements Supplier<AgroalDataSourceConfigur
 
     public static final String JDBC_URL = "jdbcUrl";
     public static final String AUTO_COMMIT = "autoCommit";
+    public static final String READ_ONLY = "readOnly";
     public static final String TRACK_JDBC_RESOURCES = "trackJdbcResources";
     public static final String LOGIN_TIMEOUT = "loginTimeout";
     public static final String INITIAL_SQL = "initialSQL";
@@ -211,6 +212,7 @@ public class AgroalPropertiesReader implements Supplier<AgroalDataSourceConfigur
 
         apply( connectionFactorySupplier::jdbcUrl, identity(), properties, JDBC_URL );
         apply( connectionFactorySupplier::autoCommit, Boolean::parseBoolean, properties, AUTO_COMMIT );
+        apply( connectionFactorySupplier::readOnly, Boolean::parseBoolean, properties, READ_ONLY );
         apply( connectionFactorySupplier::trackJdbcResources, Boolean::parseBoolean, properties, TRACK_JDBC_RESOURCES );
         apply( connectionFactorySupplier::loginTimeout, Duration::parse, properties, LOGIN_TIMEOUT );
         apply( connectionFactorySupplier::initialSql, identity(), properties, INITIAL_SQL );

--- a/agroal-hikari/src/main/java/io/agroal/hikari/HikariUnderTheCovers.java
+++ b/agroal-hikari/src/main/java/io/agroal/hikari/HikariUnderTheCovers.java
@@ -66,6 +66,7 @@ public class HikariUnderTheCovers implements AgroalDataSource {
 
         hikariConfig.setJdbcUrl( factoryConfiguration.jdbcUrl() );
         hikariConfig.setAutoCommit( factoryConfiguration.autoCommit() );
+        hikariConfig.setReadOnly( factoryConfiguration.readOnly() );
         hikariConfig.setConnectionInitSql( factoryConfiguration.initialSql() );
 
         for ( AgroalSecurityProvider provider : configuration.connectionPoolConfiguration().connectionFactoryConfiguration().securityProviders() ) {

--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionFactory.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionFactory.java
@@ -242,6 +242,9 @@ public final class ConnectionFactory implements ResourceRecoveryFactory {
         }
 
         connection.setAutoCommit( configuration.autoCommit() );
+        if ( configuration.readOnly() ) {
+            connection.setReadOnly( configuration.readOnly() );
+        }
         if ( configuration.jdbcTransactionIsolation().isDefined() ) {
             connection.setTransactionIsolation( configuration.jdbcTransactionIsolation().level() );
         } else if ( defaultIsolationLevel == null ) {

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
@@ -571,7 +571,9 @@ public final class ConnectionWrapper extends AutoCloseableElement implements Con
     public void setReadOnly(boolean readOnly) throws SQLException {
         try {
             handler.traceConnectionOperation( "setReadOnly(boolean)" );
+            handler.verifyReadOnly( readOnly );
             handler.verifyEnlistment();
+            handler.setDirtyAttribute( ConnectionHandler.DirtyAttribute.READ_ONLY );
             wrappedConnection.setReadOnly( readOnly );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );

--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSource.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSource.java
@@ -225,6 +225,10 @@ public class AgroalDataSource implements io.agroal.api.AgroalDataSource, Initial
         connectionFactoryConfiguration.autoCommit( autoCommit );
     }
 
+    public void setReadOnly(boolean readOnly) {
+        connectionFactoryConfiguration.readOnly( readOnly );
+    }
+
     public void setTrackResources(boolean track) {
         connectionFactoryConfiguration.trackJdbcResources( track );
     }

--- a/agroal-test/src/test/java/io/agroal/test/narayana/ReadOnlyTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/narayana/ReadOnlyTests.java
@@ -1,0 +1,171 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.narayana;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
+import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
+import io.agroal.narayana.NarayanaTransactionIntegration;
+import io.agroal.test.MockConnection;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+import static io.agroal.test.AgroalTestGroup.FUNCTIONAL;
+import static io.agroal.test.AgroalTestGroup.TRANSACTION;
+import static io.agroal.test.MockDriver.deregisterMockDriver;
+import static io.agroal.test.MockDriver.registerMockDriver;
+import static java.text.MessageFormat.format;
+import static java.util.logging.Logger.getLogger;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
+ */
+@Tag( FUNCTIONAL )
+@Tag( TRANSACTION )
+class ReadOnlyTests {
+
+    private static final Logger logger = getLogger( ReadOnlyTests.class.getName() );
+
+    @BeforeAll
+    static void setup() {
+        registerMockDriver( ReadOnlyAwareConnection.class );
+    }
+
+    @AfterAll
+    static void teardown() {
+        deregisterMockDriver();
+    }
+
+    // --- //
+
+    @Test
+    @DisplayName( "Test default read-only with transaction" )
+    void readOnlyDefaultTest() throws SQLException {
+        TransactionManager txManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        TransactionSynchronizationRegistry txSyncRegistry = new com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple();
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .transactionIntegration( new NarayanaTransactionIntegration( txManager, txSyncRegistry ) )
+                );
+
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier ) ) {
+            try ( Connection connection = dataSource.getConnection() ) {
+                 logger.info( format( "Got connection {0} without tx", connection ) );
+
+                 assertFalse( connection.isReadOnly() );
+                 connection.setReadOnly( true );
+                 assertTrue( connection.isReadOnly() );
+                 connection.setReadOnly( false );
+                 assertFalse( connection.isReadOnly() );
+            }
+
+            txManager.begin();
+
+            try ( Connection connection = dataSource.getConnection() ) {
+                logger.info( format( "Got connection {0} with tx", connection ) );
+
+                assertFalse( connection.isReadOnly() );
+                assertThrows( SQLException.class, () -> connection.setReadOnly( true ) );
+                assertThrows( SQLException.class, () -> connection.setReadOnly( false ) );
+                assertFalse( connection.isReadOnly() );
+            }
+
+            txManager.commit();
+        } catch ( NotSupportedException | SystemException | RollbackException | HeuristicMixedException | HeuristicRollbackException e ) {
+            fail( "Exception: " + e.getMessage() );
+        }
+    }
+
+    @Test
+    @DisplayName( "Test read-only connection with transaction" )
+    void readOnlyTest() throws SQLException {
+        TransactionManager txManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        TransactionSynchronizationRegistry txSyncRegistry = new com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple();
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .transactionIntegration( new NarayanaTransactionIntegration( txManager, txSyncRegistry ) )
+                        .connectionFactoryConfiguration( AgroalConnectionFactoryConfigurationSupplier::readOnly )
+                );
+
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier ) ) {
+            try ( Connection connection = dataSource.getConnection() ) {
+                logger.info( format( "Got connection {0} without tx", connection ) );
+
+                assertTrue( connection.isReadOnly() );
+                assertThrows( SQLException.class, () -> connection.setReadOnly( false ) );
+                assertTrue( connection.isReadOnly() );
+                connection.setReadOnly( true );
+                assertTrue( connection.isReadOnly() );
+            }
+
+            txManager.begin();
+
+            try ( Connection connection = dataSource.getConnection() ) {
+                logger.info( format( "Got connection {0} with tx", connection ) );
+
+                assertTrue( connection.isReadOnly() );
+                assertThrows( SQLException.class, () -> connection.setReadOnly( true ) );
+                assertThrows( SQLException.class, () -> connection.setReadOnly( false ) );
+                assertTrue( connection.isReadOnly() );
+            }
+
+            txManager.commit();
+        } catch ( NotSupportedException | SystemException | RollbackException | HeuristicMixedException | HeuristicRollbackException e ) {
+            fail( "Exception: " + e.getMessage() );
+        }
+    }
+
+    // --- //
+
+    public static class ReadOnlyAwareConnection implements MockConnection {
+
+        private boolean autoCommit;
+        private boolean readOnly;
+
+
+        @Override
+        public boolean getAutoCommit() {
+            return autoCommit;
+        }
+
+        @Override
+        public void setAutoCommit(boolean autoCommit) {
+            this.autoCommit = autoCommit;
+        }
+
+        @Override
+        public boolean isReadOnly() throws SQLException {
+            return readOnly;
+        }
+
+        @Override
+        public void setReadOnly(boolean readOnly) throws SQLException {
+            this.readOnly = readOnly;
+        }
+
+    }
+
+}

--- a/agroal-test/src/test/java/io/agroal/test/springframework/AgroalJdbcConnectionDetailsBeanPostProcessorTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/springframework/AgroalJdbcConnectionDetailsBeanPostProcessorTests.java
@@ -17,6 +17,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.JdbcConnectionDetails;
 import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.transaction.jta.JtaTransactionManager;
 
 import java.sql.Connection;
 
@@ -73,6 +74,9 @@ class AgroalJdbcConnectionDetailsBeanPostProcessorTests {
                             .isEqualTo( "jdbc:mock" );
                     assertThat( poolConfiguration.connectionFactoryConfiguration().connectionProviderClass().getName() )
                             .isEqualTo( "io.agroal.test.MockXADataSource$Empty" );
+
+                    JtaTransactionManager txManager = context.getBean( JtaTransactionManager.class );
+                    txManager.getTransaction( null );
 
                     try ( Connection c = dataSource.getConnection() ) {
                         LOG.info( "Got connection {}", c );

--- a/agroal-test/src/test/resources/PropertiesReaderTests/agroal.properties
+++ b/agroal-test/src/test/resources/PropertiesReaderTests/agroal.properties
@@ -18,6 +18,7 @@ reapTimeout_m=10
 
 jdbcUrl=
 autoCommit=
+readOnly=
 initialSQL=
 driverClassName=
 jdbcTransactionIsolation=SERIALIZABLE


### PR DESCRIPTION
This adds a new setting, `readOnly` that keeps connections in read-only state.