### PR TITLE
fix: adding pruning of closed statements from what is tracked

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
@@ -832,4 +832,10 @@ public final class ConnectionWrapper extends AutoCloseableElement implements Con
             return statementCount != 0 || resultSetCount != 0;
         }
     }
+
+    void pruneClosedStatements() {
+        if (trackedStatements != null) {
+            trackedStatements.pruneClosed();
+        }
+    }
 }

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/StatementWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/StatementWrapper.java
@@ -83,6 +83,8 @@ public class StatementWrapper extends AutoCloseableElement implements Statement 
             if ( wrappedStatement != CLOSED_STATEMENT ) {
                 closeTrackedResultSets();
                 wrappedStatement.close();
+                pruneClosed();
+                connection.pruneClosedStatements();
             }
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
@@ -606,5 +608,10 @@ public class StatementWrapper extends AutoCloseableElement implements Statement 
     @Override
     public final String toString() {
         return "wrapped[ " + wrappedStatement + " ]";
+    }
+
+    @Override
+    protected boolean wasClosed() {
+        return this.wrappedStatement == CLOSED_STATEMENT;
     }
 }


### PR DESCRIPTION
Alternative to #127 - while those changes are logically straight-forward, they touch a lot of lines of code.

Instead I beleive we can just oppurtinistically (on statement close), quickly (check if the wrapper is already set to the closed statement), and safely (at worst we may end up repeating some pruning, but we won't invalidate the linked list) remove closed elements.

The only way to accumulate a significant number of in-memory entries is to repeat a pattern of creating concurrent statements, leaving the last one open, then closing the rest from newest to oldest. This means a leaked statement may inhibit cleanup, but that seems fine. The only further alternative is to track the number of tracked statements vs the number of open statements to drive pruning across more of the list.

closes: AG-261