### PR TITLE
FIX: fixed virtual thread blocking resulting in the SQLException "Sorry, acquisition timeout!"

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/util/AgroalSynchronizer.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/util/AgroalSynchronizer.java
@@ -3,44 +3,61 @@
 
 package io.agroal.pool.util;
 
-import java.util.concurrent.atomic.LongAdder;
-import java.util.concurrent.locks.AbstractQueuedLongSynchronizer;
+import java.io.Serializable;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
+ * Virtual-thread friendly synchronizer
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
+ * @author <a href="matt.gdefreitas@gmail.com">Limcon</a>
  */
-public final class AgroalSynchronizer extends AbstractQueuedLongSynchronizer {
+public final class AgroalSynchronizer implements Serializable {
 
     private static final long serialVersionUID = -57548578257544072L;
-    
-    private final LongAdder counter = new LongAdder();
 
-    @Override
-    protected boolean tryAcquire(long value) {
-//        if ( counter.longValue() > value) System.out.printf( "     >>>   %s got UNLOCKED!!  (%d > %d)%n", Thread.currentThread().getName(), counter.longValue(), value );
-//        else System.out.printf( "  ------  %s got LOCKED on __ %d __ (current %d) %n", Thread.currentThread().getName(), value, counter.longValue() );
-
-        // Advance when counter is greater than value
-        return counter.longValue() > value;
-    }
-
-    @Override
-    protected boolean tryRelease(long releases) {
-//        System.out.printf( "  >>>     %s releases __ %d __%n", Thread.currentThread().getName(), counter.longValue() );
-
-        counter.add( releases );
-        return true;
-    }
-
-    // --- //
+    private final AtomicLong released = new AtomicLong(0);
+    private final Semaphore signal = new Semaphore(0, true);
 
     public long getStamp() {
-        return counter.sum();
+        return released.get();
     }
 
-    public void releaseConditional() {
-        if ( hasQueuedThreads() ) {
-            release( 1 );
+    // Try to acquire permission (used to check if a connection can proceed)
+    public boolean tryAcquire(long stamp) {
+        return released.get() > stamp;
+    }
+
+    // Blocking wait with timeout (used by the connection pool to wait for availability)
+    public boolean tryAcquireNanos(long stamp, long nanosTimeout) throws InterruptedException {
+        if (released.get() > stamp) {
+            return true;
         }
+        return signal.tryAcquire(nanosTimeout, TimeUnit.NANOSECONDS);
+    }
+
+    // Release signal (used when a connection is returned)
+    public void release() {
+        released.incrementAndGet();
+        signal.release();
+    }
+
+    // Release multiple signals
+    public void release(int amount) {
+        released.addAndGet( amount );
+        signal.release( amount );
+    }
+
+    // Release only if someone is waiting
+    public void releaseConditional() {
+        if ( signal.hasQueuedThreads() ) {
+            release();
+        }
+    }
+
+    // Get the amount of threads waiting
+    public int getQueueLength() {
+        return signal.getQueueLength();
     }
 }


### PR DESCRIPTION
This pull request fixes blocking of virtual threads when using the agroal connection pool.

The current implementation uses a AbstractQueuedLongSynchronizer, that when using tryAcquireNanos, the thread spinwaits (exactly where the bug happened and where the thread that’s trying to get a new connection, but can’t, because the connection pool is full).

[The documentation](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.html#tryAcquireNanos-long-long-):

"tryAcquireNanos:

```java
public final boolean tryAcquireNanos(long arg,
                                     long nanosTimeout)
                              throws InterruptedException
```

Attempts to acquire in exclusive mode, aborting if interrupted, and failing if the given timeout elapses. Implemented by first checking interrupt status, then invoking at least once [tryAcquire(long)](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.html#tryAcquire-long-), returning on success. Otherwise, the thread is queued, possibly repeatedly blocking and unblocking, invoking [tryAcquire(long)](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.html#tryAcquire-long-) until success or the thread is interrupted or the timeout elapses. This method can be used to implement method [Lock.tryLock(long, TimeUnit)](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/Lock.html#tryLock-long-java.util.concurrent.TimeUnit-)."

The proposed implementation uses a Semaphore that disables the core for scheduling, instead of using onSpinWait().

Tests were made with the following class, running on quarkus 3.23, with 1 core and 1 maximum connection (1k virtual threads) and 10 maximum connections (100k virtual threads) and with postgres in docker:

```java
@Path("/hello")
public class GreetingResource {

    @GET
    @Produces(MediaType.TEXT_PLAIN)
    public String hello() {
        for (int i = 0; i < 1000; i++) { // 100000
            Thread.startVirtualThread(() -> {
                test();
            });
        }
        return "Hello from Quarkus REST";
    }

    public void test() {
        try {
            addPersonA();

            addPersonB();
        } catch (Exception e) {
            e.printStackTrace();
        }
    }

    @Transactional
    public void addPersonA() {
        Person p = new Person();
        p.name = "A-" + Thread.currentThread().getId();
        p.persist();
    }

    @Transactional
    public void addPersonB() {
        Person p = new Person();
        p.name = "B-" + Thread.currentThread().getId();
        p.persist();
    }
}
```

The metrics obtained for 1k virtual threads. While it was running:

```json
{
    "vendor": {
        "memoryPool.usage.max;name=G1 Survivor Space": 12182656,
        "agroal.awaiting.count;datasource=default": 30,
        "agroal.reap.count;datasource=default": 0,
        "memoryPool.usage;name=Metaspace": 83679384,
        "memoryPool.usage;name=G1 Eden Space": 0,
        "agroal.blocking.time.total;datasource=default": 51772,
        "memoryPool.usage;name=G1 Old Gen": 83304272,
        "memoryPool.usage;name=CodeCache": 21878400,
        "agroal.leak.detection.count;datasource=default": 0,
        "memory.committedNonHeap": 119930880,
        "memoryPool.usage.max;name=G1 Old Gen": 83304272,
        "memoryPool.usage.max;name=Compressed Class Space": 11698960,
        "memoryPool.usage.max;name=G1 Eden Space": 81788928,
        "agroal.destroy.count;datasource=default": 0,
        "agroal.flush.count;datasource=default": 0,
        "memory.usedNonHeap": 117256936,
        "memoryPool.usage;name=G1 Survivor Space": 4415360,
        "agroal.invalid.count;datasource=default": 0,
        "memory.freePhysicalSize": 4753502208,
        "agroal.active.count;datasource=default": 1,
        "agroal.creation.time.max;datasource=default": 108,
        "agroal.creation.time.average;datasource=default": 108,
        "agroal.blocking.time.max;datasource=default": 1662,
        "memoryPool.usage.max;name=CodeCache": 21878400,
        "cpu.processCpuTime": 10390000000,
        "agroal.creation.count;datasource=default": 1,
        "memory.freeSwapSize": 8589930496,
        "memoryPool.usage.max;name=Metaspace": 83679048,
        "agroal.creation.time.total;datasource=default": 108,
        "cpu.systemCpuLoad": 0.25,
        "agroal.blocking.time.average;datasource=default": 672,
        "agroal.available.count;datasource=default": 0,
        "memoryPool.usage;name=Compressed Class Space": 11698960,
        "memory.maxNonHeap": -1,
        "agroal.acquire.count;datasource=default": 77,
        "agroal.max.used.count;datasource=default": 1
    }
}
```

After it was running:

```json
{
    "vendor": {
        "memoryPool.usage.max;name=G1 Survivor Space": 12182656,
        "agroal.awaiting.count;datasource=default": 0,
        "agroal.reap.count;datasource=default": 0,
        "memoryPool.usage;name=Metaspace": 83800856,
        "memoryPool.usage;name=G1 Eden Space": 0,
        "agroal.blocking.time.total;datasource=default": 1768123,
        "memoryPool.usage;name=G1 Old Gen": 92003872,
        "memoryPool.usage;name=CodeCache": 17259392,
        "agroal.leak.detection.count;datasource=default": 0,
        "memory.committedNonHeap": 122224640,
        "memoryPool.usage.max;name=G1 Old Gen": 92003872,
        "memoryPool.usage.max;name=Compressed Class Space": 11713544,
        "memoryPool.usage.max;name=G1 Eden Space": 81788928,
        "agroal.destroy.count;datasource=default": 0,
        "agroal.flush.count;datasource=default": 0,
        "memory.usedNonHeap": 112774560,
        "memoryPool.usage;name=G1 Survivor Space": 10485760,
        "agroal.invalid.count;datasource=default": 0,
        "memory.freePhysicalSize": 4287057920,
        "agroal.active.count;datasource=default": 0,
        "agroal.creation.time.max;datasource=default": 108,
        "agroal.creation.time.average;datasource=default": 108,
        "agroal.blocking.time.max;datasource=default": 2020,
        "memoryPool.usage.max;name=CodeCache": 23460480,
        "cpu.processCpuTime": 14800000000,
        "agroal.creation.count;datasource=default": 1,
        "memory.freeSwapSize": 8589930496,
        "memoryPool.usage.max;name=Metaspace": 83800856,
        "agroal.creation.time.total;datasource=default": 108,
        "cpu.systemCpuLoad": 0.11200991660507587,
        "agroal.blocking.time.average;datasource=default": 865,
        "agroal.available.count;datasource=default": 1,
        "memoryPool.usage;name=Compressed Class Space": 11713544,
        "memory.maxNonHeap": -1,
        "agroal.acquire.count;datasource=default": 2044,
        "agroal.max.used.count;datasource=default": 1
    }
}
```

The metrics after it ran on 100k virtual threads:

```json
{
    "vendor": {
        "memoryPool.usage.max;name=G1 Survivor Space": 62914560,
        "agroal.awaiting.count;datasource=default": 0,
        "agroal.reap.count;datasource=default": 0,
        "memoryPool.usage;name=Metaspace": 53705768,
        "memoryPool.usage;name=G1 Eden Space": 0,
        "agroal.blocking.time.total;datasource=default": 9888813,
        "memoryPool.usage;name=G1 Old Gen": 1521483776,
        "agroal.leak.detection.count;datasource=default": 0,
        "memory.committedNonHeap": 82182144,
        "memoryPool.usage.max;name=G1 Old Gen": 1521483776,
        "memoryPool.usage.max;name=Compressed Class Space": 6638888,
        "memoryPool.usage.max;name=G1 Eden Space": 436207616,
        "agroal.destroy.count;datasource=default": 0,
        "agroal.flush.count;datasource=default": 0,
        "memory.usedNonHeap": 73357952,
        "memoryPool.usage;name=G1 Survivor Space": 62914560,
        "agroal.invalid.count;datasource=default": 0,
        "memoryPool.usage.max;name=CodeHeap 'non-profiled nmethods'": 5928960,
        "memory.freePhysicalSize": 1681793024,
        "agroal.active.count;datasource=default": 0,
        "agroal.creation.time.max;datasource=default": 135,
        "memoryPool.usage;name=CodeHeap 'non-profiled nmethods'": 5171840,
        "memoryPool.usage;name=CodeHeap 'profiled nmethods'": 6153728,
        "agroal.creation.time.average;datasource=default": 71,
        "agroal.blocking.time.max;datasource=default": 1439,
        "memoryPool.usage.max;name=CodeHeap 'non-nmethods'": 3569920,
        "cpu.processCpuTime": 432430000000,
        "agroal.creation.count;datasource=default": 10,
        "memory.freeSwapSize": 5192675328,
        "memoryPool.usage.max;name=Metaspace": 53705768,
        "agroal.creation.time.total;datasource=default": 717,
        "cpu.systemCpuLoad": 0.08006520279988494,
        "agroal.blocking.time.average;datasource=default": 49,
        "agroal.available.count;datasource=default": 10,
        "memoryPool.usage;name=CodeHeap 'non-nmethods'": 1697408,
        "memoryPool.usage;name=Compressed Class Space": 6629208,
        "memory.maxNonHeap": -1,
        "agroal.acquire.count;datasource=default": 199999,
        "memoryPool.usage.max;name=CodeHeap 'profiled nmethods'": 11076224,
        "agroal.max.used.count;datasource=default": 10
    }
}
```

All connections consumed, awaiting the connections didn't result in any blocking and all unit tests pass.