### PR TITLE
AG-274 - ConnectionCreateTimeout

### DIFF
--- a/agroal-api/src/main/java/io/agroal/api/AgroalDataSourceListener.java
+++ b/agroal-api/src/main/java/io/agroal/api/AgroalDataSourceListener.java
@@ -27,6 +27,11 @@ public interface AgroalDataSourceListener {
     default void onConnectionCreation(Connection connection) {}
 
     /**
+     * This callback is invoked when a new connection creation task times out and therefore canceled.
+     */
+    default void onConnectionCreationTimeout() {}
+
+    /**
      * This callback is invoked when a new connection can't be established.
      */
     default void onConnectionCreationFailure(SQLException sqlException) {}

--- a/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionPoolConfiguration.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionPoolConfiguration.java
@@ -153,6 +153,17 @@ public interface AgroalConnectionPoolConfiguration {
      */
     void setAcquisitionTimeout(Duration timeout);
 
+    /**
+     * The maximum amount of time the agroal housekeeping thread may be blocked waiting for a new connection.
+     * A duration of {@link Duration#ZERO} means that a thread will wait indefinitely.
+     */
+    Duration connectionCreateTimeout();
+
+    /**
+     * Sets a new amount of time the agroal housekeeping thread may be blocked waiting for a new connection. Threads already blocked when this value changes do not see the new value when they unblock.
+     * A duration of {@link Duration#ZERO} means that a thread will wait indefinitely.
+     */
+    void setConnectionCreateTimeout(Duration timeout);
     // --- //
 
     /**

--- a/agroal-pool/src/main/java/io/agroal/pool/CreateConnectionCallable.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/CreateConnectionCallable.java
@@ -1,0 +1,6 @@
+package io.agroal.pool;
+
+import java.util.concurrent.Callable;
+
+public interface CreateConnectionCallable extends Callable<ConnectionHandler> {
+}

--- a/agroal-pool/src/main/java/io/agroal/pool/CreateConnectionFuture.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/CreateConnectionFuture.java
@@ -1,0 +1,11 @@
+package io.agroal.pool;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+
+public class CreateConnectionFuture extends FutureTask<ConnectionHandler> {
+
+    public CreateConnectionFuture(Callable<ConnectionHandler> callable) {
+        super(callable);
+    }
+}

--- a/agroal-pool/src/main/java/io/agroal/pool/util/ListenerHelper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/util/ListenerHelper.java
@@ -32,6 +32,12 @@ public final class ListenerHelper {
         }
     }
 
+    public static void fireOnConnectionCreationTimeout(AgroalDataSourceListener[] listeners) {
+        for ( AgroalDataSourceListener listener : listeners ) {
+            listener.onConnectionCreationTimeout();
+        }
+    }
+
     public static void fireOnConnectionCreationFailure(AgroalDataSourceListener[] listeners, SQLException sqlException) {
         for ( AgroalDataSourceListener listener : listeners ) {
             listener.onConnectionCreationFailure( sqlException );

--- a/agroal-test/pom.xml
+++ b/agroal-test/pom.xml
@@ -18,10 +18,16 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.agroal</groupId>
             <artifactId>agroal-api</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.agroal</groupId>
@@ -51,7 +57,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${version.org.junit.jupiter}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
         <!-- OSGi -->
         <dependency>

--- a/agroal-test/src/main/java/io/agroal/test/BlockingMockDriver.java
+++ b/agroal-test/src/main/java/io/agroal/test/BlockingMockDriver.java
@@ -1,0 +1,28 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.sql.Connection;
+import java.util.Properties;
+
+
+/**
+ *  BlockingMockDriver simply blocks during the entire connection creation phase
+ *  furthermore it is not interruptible from a .chancel() of the thread
+ */
+public class BlockingMockDriver implements MockDriver {
+
+     @Override
+     public Connection connect(String url, Properties info) {
+         try(ServerSocket serverSocket = new ServerSocket(0)) {
+             serverSocket.accept();
+         } catch (IOException e) {
+             throw new RuntimeException(e);
+         }
+         return new MockConnection.Empty();
+     }
+
+}

--- a/agroal-test/src/main/java/io/agroal/test/ConnectionListener.java
+++ b/agroal-test/src/main/java/io/agroal/test/ConnectionListener.java
@@ -1,0 +1,73 @@
+package io.agroal.test;
+
+import io.agroal.api.AgroalDataSourceListener;
+
+import java.sql.Connection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConnectionListener implements AgroalDataSourceListener {
+
+    AtomicInteger createdConnections = new AtomicInteger();
+    AtomicInteger canceledConnections = new AtomicInteger();
+    AtomicInteger beforeConnectionCreation = new AtomicInteger();
+
+    @Override
+    public void onConnectionCreation(Connection connection) {
+       createdConnections.getAndIncrement();
+    }
+
+    @Override
+    public void onConnectionCreationTimeout() {
+        canceledConnections.getAndIncrement();
+    }
+
+    @Override
+    public void beforeConnectionCreation() {
+        beforeConnectionCreation.getAndIncrement();
+    }
+
+    public Integer getCreatedConnections() {
+        return createdConnections.get();
+    }
+
+    public void assertConnectionCreated() {
+        assertEquals(1, getCreatedConnections());
+    }
+
+    public void assertNoConnectionCreated() {
+        assertEquals(0, getCreatedConnections());
+    }
+
+    public Integer getCanceledConnections() {
+        return canceledConnections.get();
+    }
+
+    public void assertConnectionCanceled() {
+        assertEquals(1, getCanceledConnections());
+    }
+
+    public void assertNoConnectionCanceled() {
+        assertEquals(0, getCanceledConnections());
+    }
+
+    public Integer getStartedConnectionCreations() {
+        return beforeConnectionCreation.get();
+    }
+
+    public void assertConnectionCreationStarted() {
+        assertEquals(1, getStartedConnectionCreations());
+    }
+
+    public void assertNoConnectionCreationStarted() {
+        assertEquals(0, getStartedConnectionCreations());
+    }
+
+    public void reset() {
+        createdConnections.set(0);
+        canceledConnections.set(0);
+        beforeConnectionCreation.set(0);
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/MultiStepMockDriver.java
+++ b/agroal-test/src/main/java/io/agroal/test/MultiStepMockDriver.java
@@ -1,0 +1,38 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+public class  MultiStepMockDriver implements MockDriver {
+
+    private final List<Driver> drivers;
+
+    public MultiStepMockDriver(List<Driver> drivers) {
+        this.drivers = Collections.synchronizedList(new ArrayList<>());
+        this.drivers.addAll(drivers);
+    }
+
+    @Override
+    public Connection connect( String url, Properties info ) throws SQLException {
+        Driver driver;
+        try{
+            driver = drivers.remove(0);
+        }catch (IndexOutOfBoundsException e) {
+            throw new RuntimeException("No Driver found");
+        }
+        logger.info("Start Connect with " + driver.getClass().getSimpleName());
+
+        var result = driver.connect(url, info);
+
+        logger.info("Finished Connect with " + driver.getClass().getSimpleName());
+        return result;
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/MySQLConnectMockDriver.java
+++ b/agroal-test/src/main/java/io/agroal/test/MySQLConnectMockDriver.java
@@ -1,0 +1,66 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test;
+
+import io.agroal.test.fakeserver.MySqlFakeServer;
+import io.agroal.test.fakeserver.ServerBehavior;
+import org.junit.platform.commons.util.StringUtils;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+
+public class MySQLConnectMockDriver implements MockDriver {
+     private final ServerBehavior behavior;
+     private final Duration connectTimeout;
+     private final Duration socketTimeout;
+
+    public MySQLConnectMockDriver(ServerBehavior behavior) {
+        this(behavior, Duration.ofSeconds(0), Duration.ofSeconds(0));
+    }
+
+     public MySQLConnectMockDriver(ServerBehavior behavior, Duration connectTimeout, Duration socketTimeout) {
+         this.behavior = behavior;
+         this.connectTimeout = connectTimeout;
+         this.socketTimeout = socketTimeout;
+     }
+
+     @Override
+     public Connection connect(String url, Properties info) {
+         try (var server = new MySqlFakeServer(this.behavior)) {
+             Executors.newSingleThreadExecutor().execute(server);
+             String hostAndPort = "localhost:" + server.getPort();
+
+             List<String> params = new ArrayList<>();
+             if (connectTimeout != null) {
+                 params.add("connectTimeout="+ connectTimeout.toMillis());
+             }
+             if (socketTimeout != null) {
+                 params.add("socketTimeout="+ socketTimeout.toMillis());
+             }
+
+             String connParams = "";
+             if(!params.isEmpty()){
+                 connParams = "?" + String.join("&", params);
+             }
+
+             String connUrl = "jdbc:mysql://"+hostAndPort+"/test" + connParams;
+             Driver driver = DriverManager.drivers().filter(d -> d.getClass().getName().startsWith( "com.mysql" ) ).findFirst().orElseThrow();
+             return driver.connect(connUrl, info);
+         } catch (Exception e) {
+             throw new RuntimeException(e);
+         }
+     }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return StringUtils.isBlank(url);
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/NoWarningsAgroalListener.java
+++ b/agroal-test/src/main/java/io/agroal/test/NoWarningsAgroalListener.java
@@ -1,0 +1,20 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test;
+
+import io.agroal.api.AgroalDataSourceListener;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class NoWarningsAgroalListener implements AgroalDataSourceListener {
+
+    @Override
+    public void onWarning(String message) {
+        fail( "Unexpected warning " + message );
+    }
+
+    @Override
+    public void onWarning(Throwable throwable) {
+        fail( "Unexpected warning " + throwable.getMessage() );
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/WarningsAgroalListener.java
+++ b/agroal-test/src/main/java/io/agroal/test/WarningsAgroalListener.java
@@ -1,0 +1,79 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test;
+
+import io.agroal.api.AgroalDataSourceListener;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static java.util.logging.Logger.getLogger;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WarningsAgroalListener implements AgroalDataSourceListener {
+
+    static final Logger logger = getLogger( WarningsAgroalListener.class.getName() );
+    private final List<String> warnings = Collections.synchronizedList(new ArrayList<>());
+    private final List<String> failures = Collections.synchronizedList(new ArrayList<>());
+
+
+    @Override
+    public void onWarning(String message) {
+        warnings.add( message );
+        logger.info( "Expected WARN: " + message );
+    }
+
+    @Override
+    public void onWarning(Throwable throwable) {
+        onWarning( stackTraceAsString(throwable) );
+    }
+
+    @Override
+    public void onConnectionCreationFailure(SQLException sqlException) {
+        var message = stackTraceAsString(sqlException);
+        failures.add( message );
+        logger.info( "Expected FAILURE: " + message );
+    }
+
+    public int warningCount() {
+        return warnings.size();
+    }
+
+    public int failuresCount() {
+        return failures.size();
+    }
+
+    public void assertAnyWarningStartsWith( String startOfMessage ) {
+        var result = warnings.stream().anyMatch( w -> w.startsWith( startOfMessage ) );
+        assertTrue(result);
+    }
+
+    public void assertAnyFailureStartsWith( String startOfMessage ) {
+        var result = failures.stream().anyMatch( w -> w.startsWith( startOfMessage ) );
+        assertTrue(result);
+    }
+
+    private static String stackTraceAsString( Throwable throwable ) {
+        var s = new StringWriter();
+        var p = new PrintWriter(s);
+        throwable.printStackTrace(p);
+        return s.toString();
+    }
+
+    public void assertNoConnectionFailures() {
+        assertEquals(0, failuresCount());
+    }
+
+    public void reset() {
+        warnings.clear();
+        failures.clear();
+    }
+}
+

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/AcceptConnectionAndClose.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/AcceptConnectionAndClose.java
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public class AcceptConnectionAndClose implements ServerBehavior {
+
+    @Override
+    public void start(ServerSocket server) throws IOException {
+        var socket = server.accept();
+        socket.close();
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/AcceptConnectionAndDoNotRespond.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/AcceptConnectionAndDoNotRespond.java
@@ -1,0 +1,25 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class AcceptConnectionAndDoNotRespond implements ServerBehavior {
+
+    protected Socket socket;
+
+    @Override
+    public void start(ServerSocket server) throws IOException {
+        this.socket = server.accept();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if(this.socket != null) {
+            this.socket.close();
+        }
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/MySqlFakeServer.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/MySqlFakeServer.java
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public class MySqlFakeServer implements AutoCloseable, Runnable {
+
+    private final ServerSocket server;
+    private final int port;
+    private final ServerBehavior behavior;
+
+    public MySqlFakeServer(ServerBehavior behavior) throws IOException {
+        this.behavior = behavior;
+        this.server = new ServerSocket(0);
+        this.port = server.getLocalPort();
+    }
+
+    @Override
+    public void run() {
+        try {
+            behavior.start(server);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.behavior.close();
+        this.server.close();
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/NotAcceptConnection.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/NotAcceptConnection.java
@@ -1,0 +1,13 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.net.ServerSocket;
+
+public class NotAcceptConnection implements ServerBehavior {
+
+    @Override
+    public void start(ServerSocket server) {
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/ServerBehavior.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/ServerBehavior.java
@@ -1,0 +1,15 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.net.ServerSocket;
+
+public interface ServerBehavior extends AutoCloseable {
+
+    void start(ServerSocket server) throws Throwable;
+
+    @Override
+    default void close() throws Exception {
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/ServerNotListening.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/ServerNotListening.java
@@ -1,0 +1,14 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.net.ServerSocket;
+
+public class ServerNotListening implements ServerBehavior {
+
+    @Override
+    public void start(ServerSocket server) throws Throwable {
+        server.close();
+    }
+}

--- a/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTests.java
@@ -4,12 +4,13 @@
 package io.agroal.test.basic;
 
 import io.agroal.api.AgroalDataSource;
-import io.agroal.api.AgroalDataSourceListener;
 import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.api.security.AgroalSecurityProvider;
 import io.agroal.test.MockConnection;
 import io.agroal.test.MockDataSource;
+import io.agroal.test.NoWarningsAgroalListener;
+import io.agroal.test.WarningsAgroalListener;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 import static io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation.NONE;
@@ -192,50 +192,6 @@ public class NewConnectionTests {
     }
 
     // --- //
-
-    public static class WarningsAgroalListener implements AgroalDataSourceListener {
-
-        private final AtomicInteger warnings = new AtomicInteger(), failures = new AtomicInteger();
-
-        @Override
-        public void onWarning(String message) {
-            warnings.getAndIncrement();
-            logger.warning( "Unexpected WARN: " + message );
-        }
-
-        @Override
-        public void onWarning(Throwable throwable) {
-            warnings.getAndIncrement();
-            logger.warning( "Unexpected WARN" + throwable.getMessage() );
-        }
-
-        @Override
-        public void onConnectionCreationFailure(SQLException sqlException) {
-            failures.getAndIncrement();
-            logger.info( "Expected callback " + sqlException.getMessage() );
-        }
-
-        public int warningCount() {
-            return warnings.get();
-        }
-
-        public int failuresCount() {
-            return failures.get();
-        }
-    }
-
-    public static class NoWarningsAgroalListener implements AgroalDataSourceListener {
-
-        @Override
-        public void onWarning(String message) {
-            fail( "Unexpected warning " + message );
-        }
-
-        @Override
-        public void onWarning(Throwable throwable) {
-            fail( "Unexpected warning " + throwable.getMessage() );
-        }
-    }
 
     public static class FaultyUrlDataSource implements MockDataSource {
 

--- a/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTimeoutTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTimeoutTests.java
@@ -1,0 +1,375 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.basic;
+
+import com.mysql.cj.jdbc.exceptions.CommunicationsException;
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
+import io.agroal.test.BlockingMockDriver;
+import io.agroal.test.ConnectionListener;
+import io.agroal.test.MockDriver;
+import io.agroal.test.MySQLConnectMockDriver;
+import io.agroal.test.WarningsAgroalListener;
+import io.agroal.test.fakeserver.AcceptConnectionAndClose;
+import io.agroal.test.fakeserver.AcceptConnectionAndDoNotRespond;
+import io.agroal.test.fakeserver.ServerNotListening;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.logging.Logger;
+
+import static io.agroal.test.AgroalTestGroup.FUNCTIONAL;
+import static io.agroal.test.MockDriver.deregisterMockDriver;
+import static io.agroal.test.MockDriver.registerMockDriver;
+import static java.util.logging.Logger.getLogger;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Tag( FUNCTIONAL )
+public class NewConnectionTimeoutTests {
+
+    static final Logger logger = getLogger( NewConnectionTimeoutTests.class.getName() );
+
+    @BeforeAll
+    static void setup(){
+        if ( Utils.isWindowsOS() ) {
+            Utils.windowsTimerHack();
+        }
+    }
+
+    @BeforeEach
+    void startClean() {
+        deregisterMockDriver();
+    }
+
+    @AfterAll
+    static void finalTeardown() {
+        deregisterMockDriver();
+    }
+
+    // --- //
+    @Test
+    void WhenServerNotListening_ThenThrowException() throws SQLException {
+        registerMockDriver(
+                new MySQLConnectMockDriver(new ServerNotListening())
+        );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize(1)
+                        .connectionCreateTimeout(Duration.ofSeconds(1))
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener) ) {
+            var e = assertThrows(RuntimeException.class, () -> dataSource.getConnection());
+            assertEquals(CommunicationsException.class, e.getCause().getClass());
+        }
+        warningsListener.assertAnyFailureStartsWith("java.sql.SQLException: Failed to create connection due to RuntimeException");
+    }
+
+    @Test
+    void WhenServerAcceptsAndImmediatelyCloseConnection_ThenThrowException() throws SQLException {
+        registerMockDriver(
+                new MySQLConnectMockDriver(new AcceptConnectionAndClose())
+        );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize(1)
+                        .connectionCreateTimeout(Duration.ofSeconds(1))
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener) ) {
+            var e = assertThrows(RuntimeException.class, () -> dataSource.getConnection());
+            assertEquals(CommunicationsException.class, e.getCause().getClass());
+        }
+        warningsListener.assertAnyFailureStartsWith("java.sql.SQLException: Failed to create connection due to RuntimeException");
+    }
+
+    @Test
+    void WhenServerAcceptsAndDoNotRespond_ThenConnectCreateTimeoutAndTryAgain() throws SQLException {
+        registerMockDriver(
+                new MySQLConnectMockDriver(new AcceptConnectionAndDoNotRespond()),
+                new MockDriver.Empty()
+        );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize(1)
+                        .connectionCreateTimeout(Duration.ofSeconds(1))
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener) ) {
+            try ( Connection c = dataSource.getConnection() ) {
+                logger.info( "Got connection " + c + " with some URL" );
+                assertEquals(2, connectionListener.getStartedConnectionCreations());
+                assertEquals(1, connectionListener.getCanceledConnections());
+                connectionListener.assertConnectionCreated();
+                warningsListener.assertAnyWarningStartsWith("java.lang.RuntimeException: Cancelled connection attempt, because create connection timed out");
+            }
+        }
+    }
+
+    // This is a negative test to prove, that if no specific timeout is set
+    // the connection pool is stuck and freeze in that situation
+    @Test
+    void WhenNoTimeoutSetAndServerAcceptsAndDoNotRespond_ThenAcquisitionTimeoutAndConnectionCreationHangs() throws SQLException, InterruptedException {
+        registerMockDriver(
+                new MySQLConnectMockDriver(new AcceptConnectionAndDoNotRespond()),
+                new MockDriver.Empty()
+        );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize(1)
+                        .acquisitionTimeout(Duration.ofSeconds(1))
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener) ) {
+            try ( Connection c = dataSource.getConnection() ) {
+                // Supposed to fail
+                fail("Not supposed to create a connection");
+            }catch (SQLException e){
+                // Connection creation was started
+                connectionListener.assertConnectionCreationStarted();
+
+                // But Acquisition timed out
+                assertTrue(e.getMessage().contains("Acquisition"));
+
+                // ConnectionCreation was canceled
+                connectionListener.assertConnectionCanceled();
+
+                // even if we give some time to interrupt, cancel will not take effect in the connection creation thread...
+                Thread.sleep(5000);
+
+                // Single thread for creating the db connection is still running and hangs - can´t be canceled
+                // Which will block the pool, and new connections couldn´t be created
+                connectionListener.assertNoConnectionCreated();
+                warningsListener.assertNoConnectionFailures();
+            }
+
+            warningsListener.reset();
+            connectionListener.reset();
+
+            // Proof that NO new db connection can be created
+            try ( Connection c = dataSource.getConnection() ) {
+                // Supposed to fail
+                fail("Not supposed to create a connection");
+            }catch (SQLException e){
+
+                // Single priority thread in PriorityScheduledExecutor is still blocked with previous connection creation
+                // therefore connection creation was NOT started
+                connectionListener.assertNoConnectionCreationStarted();
+
+                // Second attempt also timed out
+                assertTrue(e.getMessage().contains("Acquisition"));
+
+                // Single thread for creating the db connection is still running and hangs - can´t be canceled
+                // Which will block the pool, and new connections couldn´t be created
+                connectionListener.assertNoConnectionCreated();
+                warningsListener.assertNoConnectionFailures();
+            }
+        }
+    }
+
+    // This is a test to prove, that login timeout prevents a frozen pool when the connection creation
+    // get stuck during the authentication phase
+    @Test
+    void WhenLoginTimeoutSetAndLoginDoesNotComplete_ThenAcquisitionTimeoutAndConnectionCreated() throws Exception {
+
+        registerMockDriver(  new MySQLConnectMockDriver(new AcceptConnectionAndDoNotRespond()), new MockDriver.Empty() );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .acquisitionTimeout( Duration.ofMillis( 1000 ) )
+                        .connectionFactoryConfiguration( cf -> cf
+                                .loginTimeout( Duration.ofMillis( 1000 ) )
+                        )
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener ) ) {
+            try ( Connection c = dataSource.getConnection() ) {
+                fail( "Not supposed to create a connection" ); // Supposed to fail
+            } catch ( SQLException e ) {
+                // Connection creation was started but Acquisition timed out
+                connectionListener.assertConnectionCreationStarted();
+                assertTrue( e.getMessage().contains( "Acquisition" ) );
+
+                connectionListener.assertNoConnectionCreated();
+            }
+
+            connectionListener.reset();
+
+            // Proof that NO new db connection can be created
+            try ( Connection c = dataSource.getConnection() ) {
+                logger.info( "Got connection " + c + " with some URL" );
+                assertEquals( 1, connectionListener.getStartedConnectionCreations() );
+
+                connectionListener.assertConnectionCreated();
+            }
+        }
+    }
+
+    // This is a negative test to prove, that if no connectionCreateTimeout is set
+    // the connection pool is stuck and freeze in that situation
+    // Even loginTimeout is not able to handle that, because the connection creation get stuck
+    // after the authentication phase
+    @Test
+    void WhenLoginTimeoutSetAndPostLoginCommandExecutionDoesNotComplete_ThenAcquisitionTimeoutAndConnectionCreationHangs() throws Exception {
+        // BlockingMockDriver simply blocks during the entire connection creation phase,
+        // furthermore it is not interruptible from a .chancel() of the thread.
+        // This simulates the behaviour which applies when the jdbc driver executes sql commands after the authentication phase.
+        // The login timeout only covers the authentication phase, not the commands which are executed afterward, but those commands are  part
+        // of the connection creation phase (The purpose of those commands are initializing or setting props from/to the db-server).
+        // See this as a reference:
+        // https://github.com/mysql/mysql-connector-j/blob/a7b3c94f50efbddb9f0dd69b3e0d1aaa25305cd6/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java#L1288
+        registerMockDriver( new BlockingMockDriver(), new MockDriver.Empty() );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .acquisitionTimeout( Duration.ofSeconds( 1 ) )
+                        .connectionFactoryConfiguration( cf -> cf
+                                .loginTimeout( Duration.ofSeconds( 1 ) )
+                        )
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener ) ) {
+            try ( Connection c = dataSource.getConnection() ) {
+                fail( "Not supposed to create a connection" ); // Supposed to fail
+            } catch ( SQLException e ) {
+                // Connection creation was started but Acquisition timed out
+                connectionListener.assertConnectionCreationStarted();
+                assertTrue( e.getMessage().contains( "Acquisition" ) );
+
+                // even if we give some time to interrupt, cancel will not take effect in the connection creation thread...
+                Thread.sleep( 2000 );
+
+                // Single thread for creating the db connection is still running and hangs - can't be canceled
+                // Which will block the pool, and new connections couldn't be created
+                connectionListener.assertNoConnectionCreated();
+                warningsListener.assertNoConnectionFailures();
+            }
+
+            warningsListener.reset();
+            connectionListener.reset();
+
+            // Proof that NO new db connection can be created
+            try ( Connection c = dataSource.getConnection() ) {
+                fail( "Not supposed to create a connection" ); // Supposed to fail
+            } catch ( SQLException e ) {
+                // Thread is still blocked with previous connection creation therefore connection creation was NOT started
+                connectionListener.assertNoConnectionCreationStarted();
+
+                // Second attempt also timed out
+                assertTrue( e.getMessage().contains( "Acquisition" ) );
+
+                // Single thread for creating the db connection is still running and hangs - can't be canceled
+                // Which will block the pool, and new connections couldn't be created
+                connectionListener.assertNoConnectionCreated();
+                warningsListener.assertNoConnectionFailures();
+            }
+        }
+    }
+
+    // This is a test to prove, that connectionCreateTimeout prevents a frozen pool when the connection creation
+    // get stuck in any phase. This timeout applies even after the authentication phase.
+    @Test
+    void WhenPostLoginCommandExecutionDoesNotComplete_ThenConnectCreateTimeoutAndTryAgain() throws SQLException {
+        registerMockDriver( new BlockingMockDriver(), new MockDriver.Empty() );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize(1)
+                        .connectionCreateTimeout(Duration.ofSeconds(1))
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener) ) {
+            try ( Connection c = dataSource.getConnection() ) {
+                logger.info( "Got connection " + c + " with some URL" );
+                assertEquals(2, connectionListener.getStartedConnectionCreations());
+                assertEquals(1, connectionListener.getCanceledConnections());
+                connectionListener.assertConnectionCreated();
+                warningsListener.assertAnyWarningStartsWith("java.lang.RuntimeException: Cancelled connection attempt, because create connection timed out");
+            }
+        }
+    }
+
+
+    @Test
+    void WhenServerAcceptsAndDoNotRespond_ThenNextConnectionCreationAttemptWillBeSuccessful() throws SQLException, InterruptedException {
+        registerMockDriver(
+                new MySQLConnectMockDriver(new AcceptConnectionAndDoNotRespond()),
+                new MockDriver.Empty()
+        );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize(1)
+                        .acquisitionTimeout(Duration.ofSeconds(1))
+                        .connectionCreateTimeout(Duration.ofSeconds(2))
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener) ) {
+            try ( Connection c = dataSource.getConnection() ) {
+                // Supposed to fail
+                fail("Not supposed to create a connection");
+            }catch (SQLException e){
+                // Connection creation was started
+                connectionListener.assertConnectionCreationStarted();
+
+                // Acquisition timed out
+                assertTrue(e.getMessage().contains("Acquisition"));
+
+                // ConnectionCreation was not attempted to cancel because
+                // we do not cancel if there is a dedicated connectionCreateTimeout
+                connectionListener.assertNoConnectionCanceled();
+
+                // wait for ConnectionCreation time out...
+                Thread.sleep(1500);
+
+                // ConnectionCreation canceled due to connectionCreateTimeout
+                connectionListener.assertConnectionCanceled();
+
+                // Thread for creating the db connection is still running and hangs
+                // But that does not block anymore the pool
+                connectionListener.assertNoConnectionCreated();
+                warningsListener.assertNoConnectionFailures();
+            }
+
+            warningsListener.reset();
+            connectionListener.reset();
+
+            // Proof that new db connection can be created, even if the first connection creation attempt still running and hanging!
+            try ( Connection c = dataSource.getConnection() ) {
+                logger.info( "Got connection " + c + " with some URL" );
+                connectionListener.assertConnectionCreationStarted();
+                connectionListener.assertConnectionCreated();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/AG-274

**Issue TL;DR;**
Agroal pool can get “stuck” because all new connections are created by a single background thread, and a blocked DB connect call in that thread blocks the entire pool. 
In my observed scenario the blocking happens inside the MySQL driver during a socket read with no timeout, so if a connection attempt hangs, no further connections can be created.

**Solutions considered:**
Setting a socket timeout in the jdbc props. This helps, but has also an implication on the later usage of the connection. Because then also normal SQL Statements are limited to that timeout.

**Implementation Details:**
Therefore I decided to implement a general and database driver agnostic connection creation timeout.
It is implemented as an opt‑in feature: by default the timeout is set to 0, meaning no timeout and the behavior is identical to the current implementation. If you configure the connection creation timeout to a value greater than 0, the pool will attempt to create a connection and wait up to that timeout. If the timeout elapses without a successful connection, the creation task is canceled and a new attempt is started, repeating this process until the acquisition timeout is reached.

**Testing:**
For testing I decided against a Thread.sleep implementation to simulate a connection creation which takes longer. Because Thread.sleep can be interrupted easily. This is not true when blocked by reading from a socket. Therefore I implemented a small FakeServer using ServerSockets.

**Potential follow-up:**
Before I go ahead with further improvements I wanted to check with the maintainers, if that is the right direction to solve that issue. I think we can improve the feature by tracking metrics around how many connection creations failed or timed-out etc.

If you have any questions, let me know.

Fixes #146