### PR TITLE
AG-274 - Retry connection establishment

### DIFF
--- a/agroal-test/pom.xml
+++ b/agroal-test/pom.xml
@@ -18,10 +18,16 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.agroal</groupId>
             <artifactId>agroal-api</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.agroal</groupId>
@@ -51,7 +57,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${version.org.junit.jupiter}</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
         <!-- OSGi -->
         <dependency>

--- a/agroal-test/src/main/java/io/agroal/test/ConnectionListener.java
+++ b/agroal-test/src/main/java/io/agroal/test/ConnectionListener.java
@@ -1,0 +1,53 @@
+package io.agroal.test;
+
+import io.agroal.api.AgroalDataSourceListener;
+
+import java.sql.Connection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConnectionListener implements AgroalDataSourceListener {
+
+    AtomicInteger createdConnections = new AtomicInteger();
+    AtomicInteger beforeConnectionCreation = new AtomicInteger();
+
+    @Override
+    public void onConnectionCreation(Connection connection) {
+        createdConnections.getAndIncrement();
+    }
+
+    @Override
+    public void beforeConnectionCreation() {
+        beforeConnectionCreation.getAndIncrement();
+    }
+
+    public Integer getCreatedConnections() {
+        return createdConnections.get();
+    }
+
+    public void assertConnectionCreated() {
+        assertEquals( 1, getCreatedConnections() );
+    }
+
+    public void assertNoConnectionCreated() {
+        assertEquals( 0, getCreatedConnections() );
+    }
+
+    public Integer getStartedConnectionCreations() {
+        return beforeConnectionCreation.get();
+    }
+
+    public void assertConnectionCreationStarted() {
+        assertEquals( 1, getStartedConnectionCreations() );
+    }
+
+    public void assertNoConnectionCreationStarted() {
+        assertEquals( 0, getStartedConnectionCreations() );
+    }
+
+    public void reset() {
+        createdConnections.set( 0 );
+        beforeConnectionCreation.set( 0 );
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/MockPreparedStatement.java
+++ b/agroal-test/src/main/java/io/agroal/test/MockPreparedStatement.java
@@ -103,6 +103,7 @@ public interface MockPreparedStatement extends MockStatement, PreparedStatement 
     }
 
     @Override
+    @Deprecated
     default void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
     }
 

--- a/agroal-test/src/main/java/io/agroal/test/MultiStepMockDriver.java
+++ b/agroal-test/src/main/java/io/agroal/test/MultiStepMockDriver.java
@@ -1,0 +1,36 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+public class MultiStepMockDriver implements MockDriver {
+
+    private final List<Driver> drivers;
+
+    public MultiStepMockDriver(List<Driver> drivers) {
+        this.drivers = Collections.synchronizedList( new ArrayList<>( drivers ) );
+    }
+
+    @Override
+    public Connection connect(String url, Properties info) throws SQLException {
+        try {
+            Driver driver = drivers.remove( 0 );
+
+            logger.info( "Start Connect with " + driver.getClass().getSimpleName() );
+            var result = driver.connect( url, info );
+
+            logger.info( "Finished Connect with " + driver.getClass().getSimpleName() );
+            return result;
+        } catch ( IndexOutOfBoundsException e ) {
+            throw new RuntimeException( "No Driver found" );
+        }
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/MySQLConnectMockDriver.java
+++ b/agroal-test/src/main/java/io/agroal/test/MySQLConnectMockDriver.java
@@ -1,0 +1,42 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test;
+
+import io.agroal.test.fakeserver.MySqlFakeServer;
+import io.agroal.test.fakeserver.ServerBehavior;
+import org.junit.platform.commons.util.StringUtils;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+
+public class MySQLConnectMockDriver implements MockDriver {
+
+    private final ServerBehavior behavior;
+
+    public MySQLConnectMockDriver(ServerBehavior behavior) {
+        this.behavior = behavior;
+    }
+
+    @Override
+    public Connection connect(String url, Properties info) {
+        try ( var server = new MySqlFakeServer( behavior ) ) {
+            Executors.newSingleThreadExecutor().execute( server );
+
+            Driver driver = DriverManager.drivers().filter( d -> d.getClass().getName().startsWith( "com.mysql" ) ).findFirst().orElseThrow();
+            return driver.connect( "jdbc:mysql://" + "localhost:" + server.getPort() + "/test", info );
+
+        } catch ( Exception e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    public boolean acceptsURL(String url) throws SQLException {
+        return StringUtils.isBlank( url );
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/NoWarningsAgroalListener.java
+++ b/agroal-test/src/main/java/io/agroal/test/NoWarningsAgroalListener.java
@@ -1,0 +1,21 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test;
+
+import io.agroal.api.AgroalDataSourceListener;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class NoWarningsAgroalListener implements AgroalDataSourceListener {
+
+    @Override
+    public void onWarning(String message) {
+        fail( "Unexpected warning " + message );
+    }
+
+    @Override
+    public void onWarning(Throwable throwable) {
+        fail( "Unexpected warning " + throwable.getMessage() );
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/WarningsAgroalListener.java
+++ b/agroal-test/src/main/java/io/agroal/test/WarningsAgroalListener.java
@@ -1,0 +1,89 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test;
+
+import io.agroal.api.AgroalDataSourceListener;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static java.util.logging.Logger.getLogger;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WarningsAgroalListener implements AgroalDataSourceListener {
+
+    static final Logger logger = getLogger( WarningsAgroalListener.class.getName() );
+    private final List<String> infos = Collections.synchronizedList( new ArrayList<>() );
+    private final List<String> warnings = Collections.synchronizedList( new ArrayList<>() );
+    private final List<String> failures = Collections.synchronizedList( new ArrayList<>() );
+
+    @Override
+    public void onInfo(String message) {
+        infos.add( message );
+        logger.info( "Expected INFO: " + message );
+    }
+
+    @Override
+    public void onWarning(String message) {
+        warnings.add( message );
+        logger.info( "Expected WARN: " + message );
+    }
+
+    @Override
+    public void onWarning(Throwable throwable) {
+        onWarning( stackTraceAsString( throwable ) );
+    }
+
+    @Override
+    public void onConnectionCreationFailure(SQLException sqlException) {
+        var message = stackTraceAsString( sqlException );
+        failures.add( message );
+        logger.info( "Expected FAILURE: " + sqlException.getMessage() );
+    }
+
+    public int infoCount() {
+        return infos.size();
+    }
+
+    public int warningCount() {
+        return warnings.size();
+    }
+
+    public int failuresCount() {
+        return failures.size();
+    }
+
+    public void assertAnyWarningStartsWith(String startOfMessage) {
+        var result = warnings.stream().anyMatch( w -> w.startsWith( startOfMessage ) );
+        assertTrue( result );
+    }
+
+    public void assertAnyFailureStartsWith(String startOfMessage) {
+        var result = failures.stream().anyMatch( w -> w.startsWith( startOfMessage ) );
+        assertTrue( result );
+    }
+
+    private static String stackTraceAsString(Throwable throwable) {
+        var s = new StringWriter();
+        var p = new PrintWriter( s );
+        throwable.printStackTrace( p );
+        return s.toString();
+    }
+
+    public void assertNoConnectionFailures() {
+        assertEquals( 0, failuresCount() );
+    }
+
+    public void reset() {
+        infos.clear();
+        warnings.clear();
+        failures.clear();
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/AcceptConnectionAndClose.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/AcceptConnectionAndClose.java
@@ -1,0 +1,16 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public class AcceptConnectionAndClose implements ServerBehavior {
+
+    @Override
+    public void start(ServerSocket server) throws IOException {
+        var socket = server.accept();
+        socket.close();
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/AcceptConnectionAndDoNotRespond.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/AcceptConnectionAndDoNotRespond.java
@@ -1,0 +1,25 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class AcceptConnectionAndDoNotRespond implements ServerBehavior {
+
+    protected Socket socket;
+
+    @Override
+    public void start(ServerSocket server) throws IOException {
+        socket = server.accept();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if ( socket != null ) {
+            socket.close();
+        }
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/MySqlFakeServer.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/MySqlFakeServer.java
@@ -1,0 +1,39 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public class MySqlFakeServer implements AutoCloseable, Runnable {
+
+    private final ServerSocket server;
+    private final int port;
+    private final ServerBehavior behavior;
+
+    public MySqlFakeServer(ServerBehavior behavior) throws IOException {
+        this.behavior = behavior;
+        server = new ServerSocket( 0 );
+        port = server.getLocalPort();
+    }
+
+    @Override
+    public void run() {
+        try {
+            behavior.start( server );
+        } catch ( Throwable e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public void close() throws Exception {
+        behavior.close();
+        server.close();
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/NotAcceptConnection.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/NotAcceptConnection.java
@@ -1,0 +1,13 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.net.ServerSocket;
+
+public class NotAcceptConnection implements ServerBehavior {
+
+    @Override
+    public void start(ServerSocket server) {
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/ServerBehavior.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/ServerBehavior.java
@@ -1,0 +1,15 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.net.ServerSocket;
+
+public interface ServerBehavior extends AutoCloseable {
+
+    void start(ServerSocket server) throws Throwable;
+
+    @Override
+    default void close() throws Exception {
+    }
+}

--- a/agroal-test/src/main/java/io/agroal/test/fakeserver/ServerNotListening.java
+++ b/agroal-test/src/main/java/io/agroal/test/fakeserver/ServerNotListening.java
@@ -1,0 +1,14 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.fakeserver;
+
+import java.net.ServerSocket;
+
+public class ServerNotListening implements ServerBehavior {
+
+    @Override
+    public void start(ServerSocket server) throws Throwable {
+        server.close();
+    }
+}

--- a/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTests.java
@@ -4,12 +4,13 @@
 package io.agroal.test.basic;
 
 import io.agroal.api.AgroalDataSource;
-import io.agroal.api.AgroalDataSourceListener;
 import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.api.security.AgroalSecurityProvider;
 import io.agroal.test.MockConnection;
 import io.agroal.test.MockDataSource;
+import io.agroal.test.NoWarningsAgroalListener;
+import io.agroal.test.WarningsAgroalListener;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 import static io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation.NONE;
@@ -192,50 +192,6 @@ public class NewConnectionTests {
     }
 
     // --- //
-
-    public static class WarningsAgroalListener implements AgroalDataSourceListener {
-
-        private final AtomicInteger warnings = new AtomicInteger(), failures = new AtomicInteger();
-
-        @Override
-        public void onWarning(String message) {
-            warnings.getAndIncrement();
-            logger.warning( "Unexpected WARN: " + message );
-        }
-
-        @Override
-        public void onWarning(Throwable throwable) {
-            warnings.getAndIncrement();
-            logger.warning( "Unexpected WARN" + throwable.getMessage() );
-        }
-
-        @Override
-        public void onConnectionCreationFailure(SQLException sqlException) {
-            failures.getAndIncrement();
-            logger.info( "Expected callback " + sqlException.getMessage() );
-        }
-
-        public int warningCount() {
-            return warnings.get();
-        }
-
-        public int failuresCount() {
-            return failures.get();
-        }
-    }
-
-    public static class NoWarningsAgroalListener implements AgroalDataSourceListener {
-
-        @Override
-        public void onWarning(String message) {
-            fail( "Unexpected warning " + message );
-        }
-
-        @Override
-        public void onWarning(Throwable throwable) {
-            fail( "Unexpected warning " + throwable.getMessage() );
-        }
-    }
 
     public static class FaultyUrlDataSource implements MockDataSource {
 

--- a/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTimeoutTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTimeoutTests.java
@@ -1,0 +1,303 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.basic;
+
+import com.mysql.cj.jdbc.exceptions.CommunicationsException;
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
+import io.agroal.test.ConnectionListener;
+import io.agroal.test.MockDriver;
+import io.agroal.test.MySQLConnectMockDriver;
+import io.agroal.test.WarningsAgroalListener;
+import io.agroal.test.fakeserver.AcceptConnectionAndClose;
+import io.agroal.test.fakeserver.AcceptConnectionAndDoNotRespond;
+import io.agroal.test.fakeserver.NotAcceptConnection;
+import io.agroal.test.fakeserver.ServerNotListening;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import static io.agroal.test.AgroalTestGroup.FUNCTIONAL;
+import static io.agroal.test.MockDriver.deregisterMockDriver;
+import static io.agroal.test.MockDriver.registerMockDriver;
+import static java.util.logging.Logger.getLogger;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Tag( FUNCTIONAL )
+public class NewConnectionTimeoutTests {
+
+    static final Logger logger = getLogger( NewConnectionTimeoutTests.class.getName() );
+
+    @BeforeAll
+    static void setup() {
+        if ( Utils.isWindowsOS() ) {
+            Utils.windowsTimerHack();
+        }
+    }
+
+    @BeforeEach
+    void startClean() {
+        deregisterMockDriver();
+    }
+
+    @AfterAll
+    static void finalTeardown() {
+        deregisterMockDriver();
+    }
+
+    // --- //
+
+    @Test
+    void WhenServerNotListening_ThenThrowExceptionAndTryAgain() throws SQLException {
+        registerMockDriver( new MySQLConnectMockDriver( new ServerNotListening() ), new MockDriver.Empty() );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp.maxSize( 1 ) );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener ) ) {
+            var e = assertThrows( RuntimeException.class, dataSource::getConnection );
+            assertEquals( CommunicationsException.class, e.getCause().getClass() );
+            warningsListener.assertAnyFailureStartsWith( "java.sql.SQLException: Failed to create connection due to RuntimeException" );
+            warningsListener.reset();
+
+            // subsequent call to MockDriver.Empty succeeds
+            try ( Connection c = dataSource.getConnection() ) {
+                logger.info( "Got connection " + c + " with some URL" );
+                warningsListener.assertNoConnectionFailures();
+            }
+        }
+    }
+
+    @Test
+    void WhenServerNotAcceptConnection_ThenThrowExceptionAndTryAgain() throws SQLException {
+        registerMockDriver( new MySQLConnectMockDriver( new NotAcceptConnection() ), new MockDriver.Empty() );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .connectionFactoryConfiguration( cf -> cf
+                                .loginTimeout( Duration.ofSeconds( 1 ) ) // .jdbcProperty( "socketTimeout", "1000" )
+                        )
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener ) ) {
+            var e = assertThrows( RuntimeException.class, dataSource::getConnection );
+            assertEquals( CommunicationsException.class, e.getCause().getClass() );
+            warningsListener.assertAnyFailureStartsWith( "java.sql.SQLException: Failed to create connection due to RuntimeException" );
+            warningsListener.reset();
+
+            // subsequent call to MockDriver.Empty succeeds
+            try ( Connection c = dataSource.getConnection() ) {
+                logger.info( "Got connection " + c + " with some URL" );
+                warningsListener.assertNoConnectionFailures();
+            }
+        }
+    }
+
+    @Test
+    void WhenServerAcceptsAndImmediatelyCloseConnection_ThenThrowExceptionAndTryAgain() throws SQLException {
+        registerMockDriver( new MySQLConnectMockDriver( new AcceptConnectionAndClose() ), new MockDriver.Empty() );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp.maxSize( 1 ) );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener ) ) {
+            var e = assertThrows( RuntimeException.class, dataSource::getConnection );
+            assertEquals( CommunicationsException.class, e.getCause().getClass() );
+            warningsListener.assertAnyFailureStartsWith( "java.sql.SQLException: Failed to create connection due to RuntimeException" );
+            warningsListener.reset();
+
+            // subsequent call to MockDriver.Empty succeeds
+            try ( Connection c = dataSource.getConnection() ) {
+                logger.info( "Got connection " + c + " with some URL" );
+                warningsListener.assertNoConnectionFailures();
+            }
+        }
+    }
+
+    @Test
+    void WhenServerAcceptsAndDoNotRespond_ThenThrowExceptionAndTryAgain() throws SQLException {
+        registerMockDriver( new MySQLConnectMockDriver( new AcceptConnectionAndDoNotRespond() ), new MockDriver.Empty() );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .connectionFactoryConfiguration( cf -> cf
+                                .loginTimeout( Duration.ofSeconds( 1 ) ) // .jdbcProperty( "socketTimeout", "1000" )
+                        )
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener ) ) {
+
+            // call to MySQLConnectMockDriver fails
+
+            var e = assertThrows( RuntimeException.class, dataSource::getConnection );
+            assertEquals( CommunicationsException.class, e.getCause().getClass() );
+            assertTrue( e.getMessage().contains( "Communications link failure" ) );
+
+            connectionListener.assertConnectionCreationStarted();
+            connectionListener.assertNoConnectionCreated();
+            warningsListener.assertAnyFailureStartsWith( "java.sql.SQLException: Failed to create connection due to RuntimeException" );
+
+            warningsListener.reset();
+            connectionListener.reset();
+
+            // subsequent call to MockDriver.Empty succeeds
+            try ( Connection c = dataSource.getConnection() ) {
+                logger.info( "Got connection " + c + " with some URL" );
+                assertEquals( 1, connectionListener.getStartedConnectionCreations() );
+
+                connectionListener.assertConnectionCreated();
+                warningsListener.assertNoConnectionFailures();
+            }
+        }
+    }
+
+    @Test
+    void WhenServerAcceptsAndDoNotRespond_ThenAcquisitionTimeoutAndConnectionCreationHangs() throws Exception {
+        registerMockDriver( new MySQLConnectMockDriver( new AcceptConnectionAndDoNotRespond() ), new MockDriver.Empty() );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .acquisitionTimeout( Duration.ofSeconds( 1 ) )
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener ) ) {
+            try ( Connection c = dataSource.getConnection() ) {
+                fail( "Not supposed to create a connection" ); // Supposed to fail
+            } catch ( SQLException e ) {
+                // Connection creation was started but Acquisition timed out
+                connectionListener.assertConnectionCreationStarted();
+                assertTrue( e.getMessage().contains( "Acquisition" ) );
+
+                // even if we give some time to interrupt, cancel will not take effect in the connection creation thread...
+                Thread.sleep( 2000 );
+
+                // Single thread for creating the db connection is still running and hangs - can't be canceled
+                // Which will block the pool, and new connections couldn't be created
+                connectionListener.assertNoConnectionCreated();
+                warningsListener.assertNoConnectionFailures();
+            }
+
+            warningsListener.reset();
+            connectionListener.reset();
+
+            // Proof that NO new db connection can be created
+            try ( Connection c = dataSource.getConnection() ) {
+                fail( "Not supposed to create a connection" ); // Supposed to fail
+            } catch ( SQLException e ) {
+                // Thread is still blocked with previous connection creation therefore connection creation was NOT started
+                connectionListener.assertNoConnectionCreationStarted();
+
+                // Second attempt also timed out
+                assertTrue( e.getMessage().contains( "Acquisition" ) );
+
+                // Single thread for creating the db connection is still running and hangs - can't be canceled
+                // Which will block the pool, and new connections couldn't be created
+                connectionListener.assertNoConnectionCreated();
+                warningsListener.assertNoConnectionFailures();
+            }
+        }
+    }
+
+    @Test
+    void WhenServerAcceptsAndDoNotRespond_ThenNextConnectionCreationAttemptWillBeUnsuccessful() throws Exception {
+        registerMockDriver( new MySQLConnectMockDriver( new AcceptConnectionAndDoNotRespond() ), new SlowDriver( Duration.ofMillis( 500 ) ) );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .acquisitionTimeout( Duration.ofMillis( 1500 ) )
+                        .connectionFactoryConfiguration( cf -> cf
+                                .loginTimeout( Duration.ofSeconds( 1 ) )
+                        )
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener ) ) {
+
+            // call to MySQLConnectMockDriver fails and call to SlowDriver does not finish in time
+
+            var e = assertThrows( RuntimeException.class, dataSource::getConnection );
+            assertEquals( CommunicationsException.class, e.getCause().getClass() ); // the exception here is the one of the first attempt
+            assertTrue( e.getMessage().contains( "Communications link failure" ) );
+
+            assertEquals( 2, connectionListener.getStartedConnectionCreations() );
+            connectionListener.assertNoConnectionCreated();
+            warningsListener.assertAnyFailureStartsWith( "java.sql.SQLException: Failed to create connection due to RuntimeException" );
+        }
+    }
+
+    @Test
+    void WhenServerAcceptsAndDoNotRespond_ThenNextConnectionCreationAttemptWillBeSuccessful() throws Exception {
+        registerMockDriver( new MySQLConnectMockDriver( new AcceptConnectionAndDoNotRespond() ), new MockDriver.Empty() );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .acquisitionTimeout( Duration.ofSeconds( 3 ) )
+                        .connectionFactoryConfiguration( cf -> cf
+                                .loginTimeout( Duration.ofSeconds( 1 ) )
+                        )
+                );
+
+        WarningsAgroalListener warningsListener = new WarningsAgroalListener();
+        ConnectionListener connectionListener = new ConnectionListener();
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier, warningsListener, connectionListener ) ) {
+            warningsListener.assertNoConnectionFailures();
+
+            try ( Connection c = dataSource.getConnection() ) {
+                logger.info( "Got connection " + c + " with some URL" );
+
+                // Connection creation was started but the first failed
+                assertEquals( 2, connectionListener.getStartedConnectionCreations() );
+                assertEquals( 1, warningsListener.failuresCount() );
+
+                // the retry succeeded
+                connectionListener.assertConnectionCreated();
+            }
+        }
+    }
+
+    // --- //
+
+    private static class SlowDriver extends MockDriver.Empty {
+
+        private final Duration wait;
+
+        public SlowDriver(Duration d) {
+            wait = d;
+        }
+
+        @Override
+        public Connection connect(String url, Properties info) throws SQLException {
+            try {
+                Thread.sleep( wait.toMillis() );
+                return super.connect( url, info );
+            } catch ( InterruptedException e ) {
+                throw new RuntimeException( e );
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is in  alternative to #147 

[AgroalConnectionFactoryConfiguration#loginTimeout](https://github.com/agroal/agroal/blob/2.8/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionFactoryConfiguration.java#L39) already provides a timeout for connection establishment. having a similar timeout at the pool level makes little sense.

I went a step further and implemented a retry if there's still time available within the `acquisitionTimeout`.  I choose to retry only once (after a backoff period) but this could be made either configurable or extended to the whole duration of `acquisitionTimeout`.

I adapted tests from @denniskniep with cases where `acquisitionTimeout` is not set (no retry) and also when it's set.