### PR TITLE
AG-304 -  Fix interleaving issue with the Narayana reaper thread 

### DIFF
--- a/agroal-integration-tests/pom.xml
+++ b/agroal-integration-tests/pom.xml
@@ -13,6 +13,14 @@
   <properties>
     <testcontainers.version>2.0.3</testcontainers.version>
     <assertj.version>3.27.7</assertj.version>
+    <byteman.version>4.0.26</byteman.version>
+
+    <!-- Testcontainer Docker images -->
+    <postgres.testcontainer.image>postgres:17-alpine</postgres.testcontainer.image>
+    <mysql.testcontainer.image>mysql:8.0</mysql.testcontainer.image>
+    <mariadb.testcontainer.image>mariadb:11</mariadb.testcontainer.image>
+    <mssql.testcontainer.image>mcr.microsoft.com/mssql/server:2022-CU23-ubuntu-22.04</mssql.testcontainer.image>
+    <oracle.testcontainer.image>gvenzl/oracle-free:slim-faststart</oracle.testcontainer.image>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -63,6 +71,25 @@
       <version>${version.org.slf4j}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Narayana JTA runtime (for TransactionManager in XA tests) -->
+    <dependency>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>narayana-jta</artifactId>
+      <version>${version.org.jboss.narayana}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.narayana.jts</groupId>
+      <artifactId>narayana-jts-integration</artifactId>
+      <version>${version.org.jboss.narayana}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <version>${version.org.jboss.logging}</version>
+      <scope>test</scope>
+    </dependency>
     <!-- PostgreSQL DB -->
     <dependency>
       <groupId>org.postgresql</groupId>
@@ -70,6 +97,28 @@
       <version>42.7.8</version>
       <scope>test</scope>
     </dependency>
+    <!-- MySQL DB -->
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>9.5.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- MSSQL DB -->
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <version>13.2.1.jre11</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- MariaDB -->
+    <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <version>3.5.3</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Testcontainers -->
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-junit-jupiter</artifactId>
@@ -80,6 +129,40 @@
       <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-mysql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-mssqlserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-mariadb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-oracle-free</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Oracle JDBC -->
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc11</artifactId>
+      <version>23.7.0.25.01</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Byteman (deterministic thread interleaving for race condition tests) -->
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman-bmunit5</artifactId>
+      <version>${byteman.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -88,6 +171,14 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludedGroups>testcontainers</excludedGroups>
+          <argLine>-Djdk.attach.allowAttachSelf=true -XX:+EnableDynamicAgentLoading</argLine>
+          <systemPropertyVariables>
+            <postgres.testcontainer.image>${postgres.testcontainer.image}</postgres.testcontainer.image>
+            <mysql.testcontainer.image>${mysql.testcontainer.image}</mysql.testcontainer.image>
+            <mariadb.testcontainer.image>${mariadb.testcontainer.image}</mariadb.testcontainer.image>
+            <mssql.testcontainer.image>${mssql.testcontainer.image}</mssql.testcontainer.image>
+            <oracle.testcontainer.image>${oracle.testcontainer.image}</oracle.testcontainer.image>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>
@@ -102,6 +193,15 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludedGroups>none</excludedGroups>
+              <reuseForks>false</reuseForks>
+              <argLine>-Djdk.attach.allowAttachSelf=true -XX:+EnableDynamicAgentLoading</argLine>
+              <systemPropertyVariables>
+                <postgres.testcontainer.image>${postgres.testcontainer.image}</postgres.testcontainer.image>
+                <mysql.testcontainer.image>${mysql.testcontainer.image}</mysql.testcontainer.image>
+                <mariadb.testcontainer.image>${mariadb.testcontainer.image}</mariadb.testcontainer.image>
+                <mssql.testcontainer.image>${mssql.testcontainer.image}</mssql.testcontainer.image>
+                <oracle.testcontainer.image>${oracle.testcontainer.image}</oracle.testcontainer.image>
+              </systemPropertyVariables>
             </configuration>
           </plugin>
         </plugins>

--- a/agroal-integration-tests/src/test/java/io/agroal/tests/Datasources.java
+++ b/agroal-integration-tests/src/test/java/io/agroal/tests/Datasources.java
@@ -4,14 +4,18 @@ import io.agroal.api.AgroalDataSource;
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.api.security.NamePrincipal;
 import io.agroal.api.security.SimplePassword;
+import io.agroal.narayana.NarayanaTransactionIntegration;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import java.sql.SQLException;
+import java.time.Duration;
 
 /**
  * Utility class for creating Agroal DataSources for tests
  */
-class Datasources {
+public class Datasources {
 
     private Datasources() {
         throw new IllegalAccessError("Utility class");
@@ -37,4 +41,28 @@ class Datasources {
                 );
         return AgroalDataSource.from(configurationSupplier);
     }
+
+    /**
+     * Create an XA-capable AgroalDataSource from a Testcontainers JDBC Database Container
+     */
+    public static AgroalDataSource createXADataSource(JdbcDatabaseContainer container, String xaDataSourceClassName) throws SQLException {
+        TransactionManager txManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        TransactionSynchronizationRegistry txSyncRegistry =
+                new com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple();
+
+        return AgroalDataSource.from( new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .acquisitionTimeout( Duration.ofSeconds( 10 ) )
+                        .transactionIntegration( new NarayanaTransactionIntegration( txManager, txSyncRegistry ) )
+                        .connectionFactoryConfiguration( cf -> cf
+                                .connectionProviderClassName( xaDataSourceClassName )
+                                .jdbcUrl(container.getJdbcUrl())
+                                .principal(new NamePrincipal(container.getUsername()))
+                                .credential(new SimplePassword(container.getPassword()))
+                        )
+                ));
+    }
+
+
 }

--- a/agroal-integration-tests/src/test/java/io/agroal/tests/PostgreSQLTest.java
+++ b/agroal-integration-tests/src/test/java/io/agroal/tests/PostgreSQLTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 public class PostgreSQLTest {
 
     @Container
-    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:17-alpine");
+    static PostgreSQLContainer postgres = new PostgreSQLContainer( System.getProperty( "postgres.testcontainer.image", "postgres:17-alpine" ) );
 
     AgroalDataSource datasource;
 

--- a/agroal-integration-tests/src/test/java/io/agroal/tests/xa/MSSQLXAReaperRaceTest.java
+++ b/agroal-integration-tests/src/test/java/io/agroal/tests/xa/MSSQLXAReaperRaceTest.java
@@ -1,0 +1,71 @@
+package io.agroal.tests.xa;
+
+import java.util.logging.Logger;
+
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
+
+/**
+ * XA reaper race integration test against MSSQL using Testcontainers.
+ * Uses WAITFOR DELAY for slow SQL that holds the read lock past the transaction timeout.
+ *
+ * MSSQL XA requires the JDBC XA stored procedures to be installed.
+ * The init script (mssql-xa-init.sql) installs them via sp_sqljdbc_xa_install.
+ */
+@Tag( "testcontainers" )
+@Testcontainers
+@BMUnitConfig(debug = true)
+class MSSQLXAReaperRaceTest extends XAReaperRaceTestBase {
+
+    private static final Logger logger = Logger.getLogger( MSSQLXAReaperRaceTest.class.getName() );
+
+    @Container
+    static MSSQLServerContainer mssql = new MSSQLServerContainer( System.getProperty( "mssql.testcontainer.image", "mcr.microsoft.com/mssql/server:2022-CU23-ubuntu-22.04" ) )
+            .acceptLicense()
+            .withInitScript( "mssql-xa-init.sql" );
+
+    @Override
+    String xaDataSourceClassName() {
+        return "com.microsoft.sqlserver.jdbc.SQLServerXADataSource";
+    }
+
+    @Override
+    JdbcDatabaseContainer<MSSQLServerContainer> container() {
+        return mssql;
+    }
+
+    @Override
+    String slowSQL() {
+        return "WAITFOR DELAY '00:00:04'";
+    }
+
+    /**
+     * MSSQL's MSDTC actively cancels the distributed transaction when the
+     * reaper fires, causing the in-flight WAITFOR DELAY to throw:
+     * "The Microsoft Distributed Transaction Coordinator (MS DTC) has cancelled the distributed transaction."
+     *
+     * This differs from PostgreSQL/MySQL/MariaDB where the XAConnectionLock
+     * read lock blocks end(TMFAIL) and the slow SQL completes normally.
+     */
+    @Override
+    boolean slowSQLThrowsOnReaperTimeout() {
+        return true;
+    }
+
+    @Override
+    String createTableDDL() {
+        return "IF OBJECT_ID('xa_reaper_test', 'U') IS NULL " +
+               "CREATE TABLE xa_reaper_test ( id INT PRIMARY KEY, val VARCHAR(100) )";
+    }
+
+    @Override
+    String truncateTableSQL() {
+        return "IF OBJECT_ID('xa_reaper_test', 'U') IS NOT NULL DELETE FROM xa_reaper_test";
+    }
+
+   
+}

--- a/agroal-integration-tests/src/test/java/io/agroal/tests/xa/MariaDBXAReaperRaceTest.java
+++ b/agroal-integration-tests/src/test/java/io/agroal/tests/xa/MariaDBXAReaperRaceTest.java
@@ -1,0 +1,40 @@
+package io.agroal.tests.xa;
+
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mariadb.MariaDBContainer;
+
+/**
+ * XA reaper race integration test against MariaDB using Testcontainers.
+ * Uses SLEEP() for slow SQL that holds the read lock past the transaction timeout.
+ */
+@Tag( "testcontainers" )
+@Testcontainers
+@BMUnitConfig(debug = true)
+class MariaDBXAReaperRaceTest extends XAReaperRaceTestBase {
+
+    @Container
+    static MariaDBContainer mariadb = new MariaDBContainer( System.getProperty( "mariadb.testcontainer.image", "mariadb:11" ) );
+
+    @Override
+    String xaDataSourceClassName() {
+        return "org.mariadb.jdbc.MariaDbDataSource";
+    }
+
+    @Override
+    JdbcDatabaseContainer<MariaDBContainer> container() {
+        return mariadb;
+    }
+    @Override
+    String slowSQL() {
+        return "SELECT SLEEP(4)";
+    }
+
+    @Override
+    String createTableDDL() {
+        return "CREATE TABLE IF NOT EXISTS xa_reaper_test ( id INT PRIMARY KEY, val VARCHAR(100) ) ENGINE=InnoDB";
+    }
+}

--- a/agroal-integration-tests/src/test/java/io/agroal/tests/xa/MySQLXAReaperRaceTest.java
+++ b/agroal-integration-tests/src/test/java/io/agroal/tests/xa/MySQLXAReaperRaceTest.java
@@ -1,0 +1,41 @@
+package io.agroal.tests.xa;
+
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
+
+/**
+ * XA reaper race integration test against MySQL using Testcontainers.
+ * Uses SLEEP() for slow SQL that holds the read lock past the transaction timeout.
+ */
+@Tag( "testcontainers" )
+@Testcontainers
+@BMUnitConfig(debug = true)
+class MySQLXAReaperRaceTest extends XAReaperRaceTestBase {
+
+    @Container
+    static MySQLContainer mysql = new MySQLContainer( System.getProperty( "mysql.testcontainer.image", "mysql:8.0" ) );
+
+    @Override
+    String xaDataSourceClassName() {
+        return "com.mysql.cj.jdbc.MysqlXADataSource";
+    }
+
+    @Override
+    JdbcDatabaseContainer<MySQLContainer>  container() {
+        return mysql;
+    }
+
+    @Override
+    String slowSQL() {
+        return "SELECT SLEEP(4)";
+    }
+
+    @Override
+    String createTableDDL() {
+        return "CREATE TABLE IF NOT EXISTS xa_reaper_test ( id INT PRIMARY KEY, val VARCHAR(100) ) ENGINE=InnoDB";
+    }
+}

--- a/agroal-integration-tests/src/test/java/io/agroal/tests/xa/OracleXAReaperRaceTest.java
+++ b/agroal-integration-tests/src/test/java/io/agroal/tests/xa/OracleXAReaperRaceTest.java
@@ -1,0 +1,57 @@
+package io.agroal.tests.xa;
+
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.oracle.OracleContainer;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * XA reaper race integration test against Oracle Free using Testcontainers.
+ * Uses DBMS_SESSION.SLEEP() for slow SQL that holds the read lock past the transaction timeout.
+ *
+ * Oracle XA requires specific SYS grants (dba_pending_transactions, dbms_xa, etc.).
+ * These are installed via an init script copied to the container entrypoint directory.
+ *
+ * Oracle's XAResource.end() implementation:
+ *   - Sends an OCI-level xa_end() to the database
+ *   - setTransactionTimeout() returns false — no server-side timeout propagation
+ *   - Behavior matches PostgreSQL/MySQL/MariaDB: the read lock blocks end(TMFAIL),
+ *     the slow SQL completes normally, and the connection is poisoned after end()
+ */
+@Tag( "testcontainers" )
+@Testcontainers
+@BMUnitConfig(debug = true)
+class OracleXAReaperRaceTest extends XAReaperRaceTestBase {
+
+    @Container
+    static OracleContainer oracle = new OracleContainer( System.getProperty( "oracle.testcontainer.image", "gvenzl/oracle-free:slim-faststart" ) )
+            .withUsername( "test" )
+            .withPassword( "test" )
+            .withCopyToContainer(
+                    MountableFile.forClasspathResource( "oracle-xa-init.sql" ),
+                    "/container-entrypoint-initdb.d/01-xa-setup.sql" );
+
+    @Override
+    String xaDataSourceClassName() {
+        return "oracle.jdbc.xa.client.OracleXADataSource";
+    }
+
+    @Override
+    JdbcDatabaseContainer<OracleContainer>  container() {
+        return oracle;
+    }
+
+    @Override
+    String slowSQL() {
+        return "BEGIN DBMS_SESSION.SLEEP(4); END;";
+    }
+
+    @Override
+    String createTableDDL() {
+        return "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE xa_reaper_test ( id NUMBER(10) PRIMARY KEY, val VARCHAR2(100) )'; " +
+               "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;";
+    }
+}

--- a/agroal-integration-tests/src/test/java/io/agroal/tests/xa/PostgreSQLXAReaperRaceTest.java
+++ b/agroal-integration-tests/src/test/java/io/agroal/tests/xa/PostgreSQLXAReaperRaceTest.java
@@ -1,0 +1,36 @@
+package io.agroal.tests.xa;
+
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+/**
+ * XA reaper race integration test against PostgreSQL using Testcontainers.
+ * Uses pg_sleep() for slow SQL that holds the read lock past the transaction timeout.
+ */
+@Tag( "testcontainers" )
+@Testcontainers
+@BMUnitConfig(debug = true)
+class PostgreSQLXAReaperRaceTest extends XAReaperRaceTestBase {
+
+    @Container
+    static PostgreSQLContainer postgres = new PostgreSQLContainer( System.getProperty( "postgres.testcontainer.image", "postgres:17-alpine" ) );
+
+    @Override
+    String xaDataSourceClassName() {
+        return "org.postgresql.xa.PGXADataSource";
+    }
+
+    @Override
+    JdbcDatabaseContainer<PostgreSQLContainer>  container() {
+        return postgres;
+    }
+
+    @Override
+    String slowSQL() {
+        return "SELECT pg_sleep(4)";
+    }
+}

--- a/agroal-integration-tests/src/test/java/io/agroal/tests/xa/XAReaperRaceTestBase.java
+++ b/agroal-integration-tests/src/test/java/io/agroal/tests/xa/XAReaperRaceTestBase.java
@@ -1,0 +1,162 @@
+package io.agroal.tests.xa;
+
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+import org.jboss.byteman.contrib.bmunit.BMScript;
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.jboss.byteman.contrib.bmunit.WithByteman;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.AgroalDataSourceListener;
+import io.agroal.tests.Datasources;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+
+
+@WithByteman
+@BMUnitConfig(debug = true)
+abstract class XAReaperRaceTestBase {
+
+    private static final Logger logger = Logger.getLogger( XAReaperRaceTestBase.class.getName() );
+
+    // Set by Byteman rule when rollback() completes successfully on the reaper thread
+    static volatile boolean rollbackSucceeded;
+
+    public static void markRollbackSucceeded() {
+        rollbackSucceeded = true;
+    }
+
+    abstract String xaDataSourceClassName();
+    abstract JdbcDatabaseContainer container();
+
+    abstract String slowSQL();
+
+    /**
+     * Whether this driver throws from the slow SQL when the reaper fires mid-execution.
+     *
+     * Most drivers (PostgreSQL, MySQL, MariaDB) let the slow SQL complete normally
+     * because end(TMFAIL) does not interrupt the in-flight statement.
+     *
+     * MSSQL throws because MSDTC actively cancels the distributed transaction
+     * on the server side, independently of the Java-level XA resource.
+     */
+    boolean slowSQLThrowsOnReaperTimeout() {
+        return false;
+    }
+
+    String createTableDDL() {
+        return "CREATE TABLE IF NOT EXISTS xa_reaper_test ( id INT PRIMARY KEY, val VARCHAR(100) )";
+    }
+
+    String truncateTableSQL() {
+        return "DELETE FROM xa_reaper_test";
+    }
+
+
+    protected void verifyXASupported( AgroalDataSource dataSource ) {
+        TransactionManager txManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        try {
+            txManager.setTransactionTimeout( 10 );
+            txManager.begin();
+            dataSource.getConnection().close();
+            txManager.rollback();
+        } catch ( Exception e ) {
+            try { txManager.rollback(); } catch ( Exception ignore ) {}
+            assumeTrue( false, "XA not supported: " + e.getMessage() );
+        }
+    }
+
+    @Test
+    @BMScript("reaper")
+    public void testInterleave() throws Exception {
+
+        TransactionManager txManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+
+        try ( AgroalDataSource dataSource = Datasources.createXADataSource(container(), xaDataSourceClassName()) ) {
+            verifyXASupported( dataSource );
+
+            // Create table using plain Statement (not PreparedStatement)
+            // so the Byteman rule on PreparedStatementWrapper.execute() does not fire
+            try ( Connection setup = dataSource.getConnection() ) {
+                setup.createStatement().execute( createTableDDL() );
+                setup.createStatement().execute( truncateTableSQL() );
+            }
+
+            rollbackSucceeded = false;
+
+            // Short timeout — the real TransactionReaper will fire after this
+            txManager.setTransactionTimeout( 2 );
+            txManager.begin();
+            Connection connection = dataSource.getConnection();
+
+            // Prepare INSERT but do not execute yet.
+            // Byteman activates interleave sync AFTER this call returns.
+            PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO xa_reaper_test (id, val) VALUES (1, 'interleave-test')" );
+
+            // The app thread calls execute() — Byteman holds it at AT ENTRY
+            // until the TransactionReaper fires (~2s) and reaches rollback()
+            // AT ENTRY.  The reaper is then held at rollback() while the app
+            // thread attempts the INSERT.
+            //
+            // The effect of the INSERT depends on the driver's end() implementation:
+            //   - MSSQL:      end() disassociates at server level; INSERT runs in
+            //                 auto-commit and is immediately committed (data leak)
+            //   - Oracle:     end() disassociates; INSERT starts a local TX that
+            //                 blocks the subsequent rollback (XAER_PROTO)
+            //   - PostgreSQL: end() only updates JDBC driver state, not the server;
+            //                 INSERT is still inside the DB transaction and is
+            //                 covered by the subsequent rollback (no data leak)
+
+            try {
+                ps.execute();
+                logger.warning( "INSERT must be rejected after end(TMFAIL) — connection should be poisoned" );
+            } catch ( SQLException e ) {
+                logger.info( "INSERT correctly rejected: " + e.getMessage() );
+                e.printStackTrace();
+            }
+
+            // Detach the timed-out TX from the app thread.
+            // Byteman releases the reaper here (AT INVOKE suspend) so it can
+            // proceed with the actual rollback.
+            try { txManager.suspend(); } catch ( SystemException ignore ) { }
+
+            // getConnection() blocks until the reaper finishes (rollback + connection return)
+            // because pool maxSize=1.  The pool has a 10s acquisitionTimeout so that a
+            // failed rollback (e.g. Oracle XAER_PROTO) that leaves the connection stuck
+            // does not hang the test forever.
+            Connection verify = null;
+            try {
+                verify = dataSource.getConnection();
+                assertTrue( rollbackSucceeded, "Reaper's rollback() must have completed successfully" );
+            } catch ( SQLException e ) {
+                // Acquisition timed out — the connection is stuck because rollback failed.
+                // Increase pool size to get a fresh connection and still verify data leaks.
+                logger.warning( "Connection stuck after rollback failure, expanding pool: " + e.getMessage() );
+                dataSource.getConfiguration().connectionPoolConfiguration().setMaxSize( 2 );
+                verify = dataSource.getConnection();
+            }
+
+            try ( Connection c = verify ) {
+                ResultSet rs = c.createStatement()
+                        .executeQuery( "SELECT COUNT(*) FROM xa_reaper_test" );
+                rs.next();
+                int count = rs.getInt( 1 );
+                if ( count != 0 ) {
+                    fail( "Data leak: xa_reaper_test has " + count + " rows but should have 0" );
+                }
+            }
+        }
+    }
+}

--- a/agroal-integration-tests/src/test/resources/mssql-xa-init.sql
+++ b/agroal-integration-tests/src/test/resources/mssql-xa-init.sql
@@ -1,0 +1,3 @@
+-- Install the JDBC XA stored procedures required for XA transactions.
+-- Must run as SA before any XA enlistment is attempted.
+EXEC sp_sqljdbc_xa_install;

--- a/agroal-integration-tests/src/test/resources/oracle-xa-init.sql
+++ b/agroal-integration-tests/src/test/resources/oracle-xa-init.sql
@@ -1,0 +1,7 @@
+-- Grant XA transaction privileges to the test user.
+-- These run as SYS via the container entrypoint init mechanism.
+GRANT SELECT ON sys.dba_pending_transactions TO test;
+GRANT SELECT ON sys.pending_trans$ TO test;
+GRANT SELECT ON sys.dba_2pc_pending TO test;
+GRANT EXECUTE ON sys.dbms_xa TO test;
+GRANT EXECUTE ON sys.dbms_session TO test;

--- a/agroal-integration-tests/src/test/resources/reaper.btm
+++ b/agroal-integration-tests/src/test/resources/reaper.btm
@@ -1,0 +1,77 @@
+# Arms the interleave mechanism once the INSERT statement is prepared.
+# All subsequent rules check this flag so they only fire during the test window.
+RULE Enable interleave sync after prepareStatement
+CLASS io.agroal.tests.xa.XAReaperRaceTestBase
+METHOD testInterleave
+AFTER INVOKE prepareStatement
+BIND NOTHING
+IF TRUE
+DO debug("enabling interleave sync flag"),
+   flag("interleave-active")
+ENDRULE
+
+# Blocks the app thread inside execute() until the reaper has passed through
+# end() and reached rollback() AT ENTRY — creating the race window.
+RULE App thread waits at execute entry for reaper to reach rollback
+CLASS io.agroal.pool.wrapper.PreparedStatementWrapper
+METHOD execute()
+AT ENTRY
+BIND NOTHING
+IF flagged("interleave-active")
+DO debug("app thread: waiting for reaper to complete end(TMFAIL) and reach rollback entry"),
+   waitFor("reaper-at-rollback", 30000),
+   debug("app thread: reaper is held at rollback entry, proceeding with execute()")
+ENDRULE
+
+# When the reaper reaches rollback(), it has already completed end().
+# Signal the app thread to proceed with the INSERT, then hold the reaper
+# so the INSERT runs before rollback() executes.
+RULE Reaper signals app and holds at rollback entry
+CLASS io.agroal.narayana.BaseXAResource
+METHOD rollback
+AT ENTRY
+BIND NOTHING
+IF flagged("interleave-active")
+DO flag("rollback-started"),
+   debug("reaper: end(TMFAIL) done, signaling app thread and holding"),
+   signalWake("reaper-at-rollback", false),
+   waitFor("app-execute-done", 30000),
+   debug("reaper: app done, proceeding with rollback()")
+ENDRULE
+
+# On successful rollback, mark the flag so the test can verify it.
+RULE Mark rollback succeeded
+CLASS io.agroal.narayana.BaseXAResource
+METHOD rollback
+AT EXIT
+BIND NOTHING
+IF flagged("rollback-started")
+DO clear("rollback-started"),
+   debug("reaper: rollback() completed successfully"),
+   io.agroal.tests.xa.XAReaperRaceTestBase.markRollbackSucceeded()
+ENDRULE
+
+# On failed rollback (e.g. Oracle XAER_PROTO), clear the flag so that
+# a Narayana retry cannot falsely set rollbackSucceeded.
+RULE Clear rollback-started on failure
+CLASS io.agroal.narayana.BaseXAResource
+METHOD rollback
+AT EXCEPTION EXIT
+BIND NOTHING
+IF flagged("rollback-started")
+DO clear("rollback-started"),
+   debug("reaper: rollback() failed, clearing rollback-started")
+ENDRULE
+
+# After the app thread's INSERT attempt, release the reaper so it can
+# proceed with rollback(). Clears interleave-active to disarm all rules.
+RULE Release reaper before suspend
+CLASS io.agroal.tests.xa.XAReaperRaceTestBase
+METHOD testInterleave
+AT INVOKE suspend
+BIND NOTHING
+IF flagged("interleave-active")
+DO debug("app thread: execute attempt finished, releasing reaper"),
+   clear("interleave-active"),
+   signalWake("app-execute-done", false)
+ENDRULE

--- a/agroal-narayana/src/main/java/io/agroal/narayana/BaseXAResource.java
+++ b/agroal-narayana/src/main/java/io/agroal/narayana/BaseXAResource.java
@@ -64,6 +64,9 @@ public class BaseXAResource implements XAResourceWrapper {
 
     @Override
     public void end(Xid xid, int flags) throws XAException {
+        if ( ( flags & XAResource.TMFAIL ) != 0 ) {
+            transactionAware.transactionBeforeCompletion( false );
+        }
         try {
             xaResource.end( xid, flags );
         } catch ( XAException xe ) {


### PR DESCRIPTION
For MSSQL the reaper rollback does not rollback the SQL executed by the prepareStatement as its connection is in local mode. 

`mvn clean install -Pit -Dtest=MSSQL*` from the agroal-integration-tests folder