### PR TITLE
Set up concurrency settings in the build workflow

### DIFF
--- a/.github/workflows/maven-action.yml
+++ b/.github/workflows/maven-action.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '0 5 * * 0'  # at 05:00 on Sunday
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Java 17 - Build


### PR DESCRIPTION
Ensures that the original build is cancelled when a PR is updated