### PR TITLE
AG-305 - Use Connection.setNetworkTimeout as a hard backstop in ConnectionValidator#sqlValidator

### DIFF
--- a/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionPoolConfiguration.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionPoolConfiguration.java
@@ -11,6 +11,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.concurrent.Executor;
 
 /**
  * The configuration of the connection pool.
@@ -211,6 +212,9 @@ public interface AgroalConnectionPoolConfiguration {
      */
     interface ConnectionValidator {
 
+        // extra buffer so setQueryTimeout can cancel the statement cleanly before the network timeout forces the socket closed
+        Duration NETWORK_TIMEOUT_BUFFER = Duration.ofSeconds( 5 );
+
         /**
          * The default validation strategy {@link Connection#isValid(int)}
          */
@@ -260,17 +264,58 @@ public interface AgroalConnectionPoolConfiguration {
          * A validator that uses the provided SQL statement for validation with a timeout (in seconds).
          * If the timeout period expires before the operation completes, the connection is invalidated.
          * A timeout of 0 means no timeout.
+         *
          */
         static ConnectionValidator sqlValidator(String sql, int timeoutSeconds) {
+            Duration duration = Duration.ofSeconds( timeoutSeconds );
+            return sqlValidator( sql, duration );
+        }
+
+        /**
+         * A validator that uses the provided SQL statement for validation with a query timeout.
+         * If the query timeout period expires before the operation completes, the connection is invalidated.
+         * A query timeout of zero means no timeout.
+         */
+        static ConnectionValidator sqlValidator(String sql, Duration queryTimeout) {
+            return sqlValidator( sql, queryTimeout, queryTimeout.isZero() ? null : queryTimeout.plus( NETWORK_TIMEOUT_BUFFER ) );
+        }
+
+        /**
+         * A validator that uses the provided SQL statement for validation with a query timeout and a configurable network timeout.
+         * If the timeout period expires before the operation completes, the connection is invalidated.
+         * A timeout of zero means no timeout.
+         * The network timeout should be greater than the query timeout to allow the query timeout to cancel the statement
+         * cleanly before the network timeout forces the socket closed.
+         * A null network timeout will keep the connection's network timeout configuration unchanged
+         */
+        static ConnectionValidator sqlValidator(String sql, Duration queryTimeout, Duration networkTimeout) {
             return new ConnectionValidator() {
                 @Override
                 public boolean isValid(Connection connection) {
+                    Executor executor = Runnable::run;
+                    int originalNetworkTimeout = 0;
+                    if ( networkTimeout != null ) {
+                        try {
+                            originalNetworkTimeout = connection.getNetworkTimeout();
+                            connection.setNetworkTimeout( executor, (int) networkTimeout.toMillis() );
+                        } catch ( Exception ignore ) {
+                            // driver may not support network timeout
+                        }
+                    }
                     try (var statement = connection.createStatement()) {
-                        statement.setQueryTimeout( timeoutSeconds );
+                        statement.setQueryTimeout( (int) queryTimeout.toSeconds() );
                         statement.execute( sql );
                         return true;
-                    } catch (Exception t) {
+                    } catch ( Exception t ) {
                         return false;
+                    } finally {
+                        if ( networkTimeout != null ) {
+                            try {
+                                connection.setNetworkTimeout( executor, originalNetworkTimeout );
+                            } catch ( Exception ignore ) {
+                                // driver may not support network timeout
+                            }
+                        }
                     }
                 }
             };

--- a/agroal-test/src/test/java/io/agroal/test/basic/PropertiesReaderTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/PropertiesReaderTests.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.Connection;
+import java.time.Duration;
 import java.time.LocalTime;
 import java.util.logging.Logger;
 
@@ -61,13 +62,13 @@ class PropertiesReaderTests {
         validator = AgroalPropertiesReader.parseConnectionValidator(connectionValidatorName);
         Assertions.assertEquals( "io.agroal.api.configuration.AgroalConnectionPoolConfiguration$ConnectionValidator$4", validator.getClass().getName() );
         Assertions.assertEquals( "select 1", getDeclaredField( validator, "val$sql" ) );
-        Assertions.assertEquals( 0, getDeclaredField( validator, "val$timeoutSeconds" ) );
+        Assertions.assertEquals( Duration.ZERO, getDeclaredField( validator, "val$queryTimeout" ) );
 
         connectionValidatorName = "sql[select 1]5000";
         validator = AgroalPropertiesReader.parseConnectionValidator(connectionValidatorName);
         Assertions.assertEquals( "io.agroal.api.configuration.AgroalConnectionPoolConfiguration$ConnectionValidator$4", validator.getClass().getName() );
         Assertions.assertEquals( "select 1", getDeclaredField( validator, "val$sql" ) );
-        Assertions.assertEquals( 5000, getDeclaredField( validator, "val$timeoutSeconds" ) );
+        Assertions.assertEquals( Duration.ofSeconds( 5000 ), getDeclaredField( validator, "val$queryTimeout" ) );
     }
 
     // --- //

--- a/agroal-test/src/test/java/io/agroal/test/basic/ValidationTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/ValidationTests.java
@@ -8,6 +8,7 @@ import io.agroal.api.AgroalDataSourceListener;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.test.MockConnection;
+import io.agroal.test.MockStatement;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +17,10 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
@@ -29,6 +33,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.logging.Logger.getLogger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -177,6 +182,94 @@ public class ValidationTests {
             return counter.get();
         }
 
+    }
+
+    @Test
+    @DisplayName( "sqlValidator with network timeout" )
+    void sqlValidatorWithNetworkTimeoutTest() throws Exception {
+        int POOL_SIZE = 1, TIMEOUT_MS = 1000;
+
+        deregisterMockDriver();
+        registerMockDriver( NetworkTimeoutTrackingConnection.class );
+        try {
+            AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                    .connectionPoolConfiguration( cp -> cp
+                            .initialSize( POOL_SIZE )
+                            .maxSize( POOL_SIZE )
+                            .acquisitionTimeout( ofMillis( TIMEOUT_MS ) )
+                            .validateOnBorrow( true )
+                            .connectionValidator( AgroalConnectionPoolConfiguration.ConnectionValidator.sqlValidator( "SELECT 1", Duration.ofSeconds( 5 ) ) )
+                    );
+
+            try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier ) ) {
+                try ( Connection connection = dataSource.getConnection() ) {
+                    assertNotNull( connection, "Expected non-null connection" );
+
+                    NetworkTimeoutTrackingConnection trackingConnection = connection.unwrap( NetworkTimeoutTrackingConnection.class );
+                    assertEquals( 5, trackingConnection.lastStatement.queryTimeout, "Expected query timeout to be set" );
+                    assertEquals( "SELECT 1", trackingConnection.lastStatement.executedSql, "Expected SQL to be executed" );
+                    assertEquals( 0, trackingConnection.getNetworkTimeout(), "Expected network timeout to be restored" );
+                    assertTrue( trackingConnection.networkTimeoutWasSet, "Expected network timeout to have been set during validation" );
+                    assertEquals( 10000, trackingConnection.networkTimeoutDuringValidation, "Expected network timeout to include 5s buffer" );
+                }
+            }
+        } finally {
+            deregisterMockDriver();
+            registerMockDriver( ValidationThrowsConnection.class );
+        }
+    }
+
+    // --- //
+
+    public static class NetworkTimeoutTrackingConnection implements MockConnection {
+
+        private int networkTimeout;
+        boolean networkTimeoutWasSet;
+        int networkTimeoutDuringValidation;
+        TrackingStatement lastStatement;
+
+        @Override
+        public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+            networkTimeout = milliseconds;
+            if ( milliseconds > 0 ) {
+                networkTimeoutWasSet = true;
+                networkTimeoutDuringValidation = milliseconds;
+            }
+        }
+
+        @Override
+        public int getNetworkTimeout() throws SQLException {
+            return networkTimeout;
+        }
+
+        @Override
+        public Statement createStatement() throws SQLException {
+            lastStatement = new TrackingStatement();
+            return lastStatement;
+        }
+
+        @SuppressWarnings( "unchecked" )
+        @Override
+        public <T> T unwrap(Class<T> target) throws SQLException {
+            return (T) this;
+        }
+    }
+
+    public static class TrackingStatement implements MockStatement {
+
+        int queryTimeout;
+        String executedSql;
+
+        @Override
+        public void setQueryTimeout(int seconds) throws SQLException {
+            queryTimeout = seconds;
+        }
+
+        @Override
+        public boolean execute(String sql) throws SQLException {
+            executedSql = sql;
+            return false;
+        }
     }
 
     // --- //


### PR DESCRIPTION
`Statement.setQueryTimeout` relies on the driver sending a cancel signal to the server, which may not work when the connection is stuck at the network level (e.g. network partition, firewall dropping packets).

Setting a network timeout on the socket ensures validation will return within the configured timeout regardless of server cooperation.
