### PR TITLE
AG-306 - Rename MultipleAcquisitionAction.OFF to LENIENT for clarity

### DIFF
--- a/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionPoolConfiguration.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/AgroalConnectionPoolConfiguration.java
@@ -193,6 +193,12 @@ public interface AgroalConnectionPoolConfiguration {
         /**
          * No restriction.
          */
+        LENIENT,
+        /**
+         * No restriction.
+         * @deprecated Use {@link #LENIENT} instead.
+         */
+        @Deprecated
         OFF,
         /**
          * Warn if thread already holds a connection.

--- a/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalConnectionPoolConfigurationSupplier.java
+++ b/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalConnectionPoolConfigurationSupplier.java
@@ -38,7 +38,7 @@ public class AgroalConnectionPoolConfigurationSupplier implements Supplier<Agroa
     ConnectionCache connectionCache = LocalConnectionCache.single();
     TransactionIntegration transactionIntegration = none();
     TransactionRequirement transactionRequirement = TransactionRequirement.OFF;
-    MultipleAcquisitionAction multipleAcquisitionAction = MultipleAcquisitionAction.OFF;
+    MultipleAcquisitionAction multipleAcquisitionAction = MultipleAcquisitionAction.LENIENT;
     boolean enhancedLeakReport;
     boolean flushOnClose;
     boolean recoveryEnable = true;
@@ -169,11 +169,12 @@ public class AgroalConnectionPoolConfigurationSupplier implements Supplier<Agroa
     }
 
     /**
-     * Sets the behaviour of the pool when a thread tries to acquire multiple connections. Default is {@link MultipleAcquisitionAction#OFF}
+     * Sets the behaviour of the pool when a thread tries to acquire multiple connections. Default is {@link MultipleAcquisitionAction#LENIENT}
      */
+    @SuppressWarnings( "deprecation" )
     public AgroalConnectionPoolConfigurationSupplier multipleAcquisition(MultipleAcquisitionAction action) {
         checkLock();
-        multipleAcquisitionAction = action;
+        multipleAcquisitionAction = action == MultipleAcquisitionAction.OFF ? MultipleAcquisitionAction.LENIENT : action;
         return this;
     }
 

--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.LongAdder;
 
 import static io.agroal.api.AgroalDataSource.FlushMode.GRACEFUL;
 import static io.agroal.api.AgroalDataSource.FlushMode.LEAK;
-import static io.agroal.api.configuration.AgroalConnectionPoolConfiguration.MultipleAcquisitionAction.OFF;
+import static io.agroal.api.configuration.AgroalConnectionPoolConfiguration.MultipleAcquisitionAction.LENIENT;
 import static io.agroal.pool.util.InterceptorHelper.fireOnConnectionAcquiredInterceptor;
 import static io.agroal.pool.util.InterceptorHelper.fireOnConnectionCreateInterceptor;
 import static io.agroal.pool.util.InterceptorHelper.fireOnConnectionDestroyInterceptor;
@@ -266,7 +266,7 @@ public final class ConnectionPool implements Pool {
     }
 
     private void checkMultipleAcquisition() throws SQLException {
-        if ( configuration.multipleAcquisition() != OFF ) {
+        if ( configuration.multipleAcquisition() != LENIENT ) {
             for ( ConnectionHandler handler : allConnections ) {
                 if ( handler.getHoldingThread() == currentThread() ) {
                     switch ( configuration.multipleAcquisition() ) {
@@ -274,7 +274,7 @@ public final class ConnectionPool implements Pool {
                             throw new SQLException( "Acquisition of multiple connections by the same Thread." );
                         case WARN:
                             fireOnWarning( listeners, "Acquisition of multiple connections by the same Thread. This can lead to pool exhaustion and eventually a deadlock!" );
-                        case OFF:
+                        case LENIENT:
                         default:
                             // no action
                     }
@@ -481,7 +481,7 @@ public final class ConnectionPool implements Pool {
         if ( leakEnabled || reapEnabled ) {
             checkedOutHandler.touch();
         }
-        if ( leakEnabled || configuration.multipleAcquisition() != OFF ) {
+        if ( leakEnabled || configuration.multipleAcquisition() != LENIENT ) {
             if ( checkedOutHandler.getHoldingThread() != null && checkedOutHandler.getHoldingThread() != currentThread() ) {
                 Throwable warn = new Throwable( "Shared connection between threads '" + checkedOutHandler.getHoldingThread().getName() + "' and '" + currentThread().getName() + "'" );
                 warn.setStackTrace( checkedOutHandler.getHoldingThread().getStackTrace() );

--- a/agroal-pool/src/main/java/io/agroal/pool/Poolless.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/Poolless.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.LongAccumulator;
 
 import static io.agroal.api.AgroalDataSource.FlushMode.ALL;
 import static io.agroal.api.AgroalDataSource.FlushMode.LEAK;
-import static io.agroal.api.configuration.AgroalConnectionPoolConfiguration.MultipleAcquisitionAction.OFF;
+import static io.agroal.api.configuration.AgroalConnectionPoolConfiguration.MultipleAcquisitionAction.LENIENT;
 import static io.agroal.pool.util.InterceptorHelper.fireOnConnectionAcquiredInterceptor;
 import static io.agroal.pool.util.InterceptorHelper.fireOnConnectionCreateInterceptor;
 import static io.agroal.pool.util.InterceptorHelper.fireOnConnectionDestroyInterceptor;
@@ -206,7 +206,7 @@ public final class Poolless implements Pool {
     }
 
     private void checkMultipleAcquisition() throws SQLException {
-        if ( configuration.multipleAcquisition() != OFF ) {
+        if ( configuration.multipleAcquisition() != LENIENT ) {
             for ( ConnectionHandler handler : allConnections ) {
                 if ( handler.getHoldingThread() == currentThread() ) {
                     switch ( configuration.multipleAcquisition() ) {
@@ -214,7 +214,7 @@ public final class Poolless implements Pool {
                             throw new SQLException( "Acquisition of multiple connections by the same Thread." );
                         case WARN:
                             fireOnWarning( listeners, "Acquisition of multiple connections by the same Thread. This can lead to pool exhaustion and eventually a deadlock!" );
-                        case OFF:
+                        case LENIENT:
                         default:
                             // no action
                     }
@@ -330,7 +330,7 @@ public final class Poolless implements Pool {
                 default:
             }
         }
-        if ( !configuration.leakTimeout().isZero() || configuration.multipleAcquisition() != OFF ) {
+        if ( !configuration.leakTimeout().isZero() || configuration.multipleAcquisition() != LENIENT ) {
             if ( checkedOutHandler.getHoldingThread() != null && checkedOutHandler.getHoldingThread() != currentThread() ) {
                 Throwable warn = new Throwable( "Shared connection between threads '" + checkedOutHandler.getHoldingThread().getName() + "' and '" + currentThread().getName() + "'" );
                 warn.setStackTrace( checkedOutHandler.getHoldingThread().getStackTrace() );


### PR DESCRIPTION
`LENIENT` better conveys the intent (multiple acquisitions allowed) and forms a natural severity spectrum with `WARN` and `STRICT`. 

The deprecated `OFF` constant is preserved for backward compatibility and normalized to `LENIENT` in the setter.


- This comes after a review in https://github.com/quarkusio/quarkus/pull/53068#discussion_r2941024247 