### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/maven-action.yml
+++ b/.github/workflows/maven-action.yml
@@ -15,7 +15,7 @@ jobs:
     name: Java 17 - Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           cache: 'maven'
@@ -23,7 +23,7 @@ jobs:
           java-package: jdk
           java-version: '17'
       - run: mvn -B install
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: agroal-repository-artifact
           path: ~/.m2/repository/io/agroal/**
@@ -38,14 +38,14 @@ jobs:
     name: Java ${{ matrix.java }} ${{ matrix.os }} - Test
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           cache: 'maven'
           distribution: 'temurin'
           java-package: jdk
           java-version: ${{ matrix.java }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: agroal-repository-artifact
           path: ~/.m2/repository/io/agroal
@@ -63,7 +63,7 @@ jobs:
     needs: [ build, test ]
     name: Java 17 - Rebuild and Deploy Snapshot Artifacts
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           cache: 'maven'

--- a/agroal-test/src/test/java/io/agroal/test/basic/BasicConcurrencyTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/BasicConcurrencyTests.java
@@ -184,7 +184,9 @@ public class BasicConcurrencyTests {
             }
         } );
 
-        if ( !acquireLatch.await( ACQUISITION_TIMEOUT_MS, MILLISECONDS ) ) {
+        long adjustedTimeout = (long) ( ACQUISITION_TIMEOUT_MS * overheadFactor );
+
+        if ( !acquireLatch.await( adjustedTimeout, MILLISECONDS ) ) {
             fail( "Did not execute within the required amount of time" );
         }
 
@@ -193,7 +195,7 @@ public class BasicConcurrencyTests {
         logger.info( "Closing the datasource" );
         dataSource.close();
 
-        if ( !releaseLatch.await( ACQUISITION_TIMEOUT_MS, MILLISECONDS ) ) {
+        if ( !releaseLatch.await( adjustedTimeout, MILLISECONDS ) ) {
             fail( "Did not execute within the required amount of time" );
         }
 


### PR DESCRIPTION
Update checkout (v5 → v6), upload-artifact (v4 → v7), and download-artifact (v4 → v8)
