### PR TITLE
AG-304 - use var handle in wrappers

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/CallableStatementWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/CallableStatementWrapper.java
@@ -8,6 +8,8 @@ import io.agroal.pool.wrapper.closed.ClosedCallableStatement;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
@@ -33,20 +35,36 @@ import java.util.Map;
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
  * @author <a href="jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
+@SuppressWarnings( "resource" )
 public final class CallableStatementWrapper extends StatementWrapper implements CallableStatement {
+
+    private static final VarHandle WRAPPED;
+
+    static {
+        try {
+            WRAPPED = MethodHandles.lookup().findVarHandle( CallableStatementWrapper.class, "wrappedStatement", CallableStatement.class );
+        } catch ( NoSuchFieldException | IllegalAccessException e ) {
+            throw new ExceptionInInitializerError( e );
+        }
+    }
+
+    private CallableStatement wrappedCallableStatement() {
+        return (CallableStatement) WRAPPED.getAcquire( this );
+    }
 
     // --- //
 
+    @SuppressWarnings( "unused" )
     private CallableStatement wrappedStatement;
 
     public CallableStatementWrapper(ConnectionWrapper connectionWrapper, CallableStatement statement, boolean trackJdbcResources, AutoCloseableElement<StatementWrapper> head, boolean defaultHoldability) {
         super( connectionWrapper, statement, trackJdbcResources, head, defaultHoldability );
-        wrappedStatement = statement;
+        WRAPPED.setRelease( this, statement );
     }
 
     @Override
     public void close() throws SQLException {
-        wrappedStatement = ClosedCallableStatement.INSTANCE;
+        WRAPPED.setRelease( this, ClosedCallableStatement.INSTANCE );
         super.close();
     }
 
@@ -56,7 +74,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void registerOutParameter(int parameterIndex, int sqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.registerOutParameter( parameterIndex, sqlType );
+            wrappedCallableStatement().registerOutParameter( parameterIndex, sqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -67,7 +85,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void registerOutParameter(int parameterIndex, int sqlType, int scale) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.registerOutParameter( parameterIndex, sqlType, scale );
+            wrappedCallableStatement().registerOutParameter( parameterIndex, sqlType, scale );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -78,7 +96,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public boolean wasNull() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.wasNull();
+            return wrappedCallableStatement().wasNull();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -89,7 +107,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public String getString(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getString( parameterIndex );
+            return wrappedCallableStatement().getString( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -100,7 +118,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public boolean getBoolean(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getBoolean( parameterIndex );
+            return wrappedCallableStatement().getBoolean( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -111,7 +129,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public byte getByte(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getByte( parameterIndex );
+            return wrappedCallableStatement().getByte( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -122,7 +140,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public short getShort(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getShort( parameterIndex );
+            return wrappedCallableStatement().getShort( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -133,7 +151,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public int getInt(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getInt( parameterIndex );
+            return wrappedCallableStatement().getInt( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -144,7 +162,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public long getLong(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getLong( parameterIndex );
+            return wrappedCallableStatement().getLong( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -155,7 +173,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public float getFloat(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getFloat( parameterIndex );
+            return wrappedCallableStatement().getFloat( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -166,7 +184,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public double getDouble(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getDouble( parameterIndex );
+            return wrappedCallableStatement().getDouble( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -178,7 +196,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public BigDecimal getBigDecimal(int parameterIndex, int scale) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getBigDecimal( parameterIndex, scale );
+            return wrappedCallableStatement().getBigDecimal( parameterIndex, scale );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -189,7 +207,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public byte[] getBytes(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getBytes( parameterIndex );
+            return wrappedCallableStatement().getBytes( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -200,7 +218,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Date getDate(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getDate( parameterIndex );
+            return wrappedCallableStatement().getDate( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -211,7 +229,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Time getTime(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getTime( parameterIndex );
+            return wrappedCallableStatement().getTime( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -222,7 +240,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Timestamp getTimestamp(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getTimestamp( parameterIndex );
+            return wrappedCallableStatement().getTimestamp( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -233,7 +251,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Object getObject(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            Object driverObject = wrappedStatement.getObject( parameterIndex );
+            Object driverObject = wrappedCallableStatement().getObject( parameterIndex );
             return driverObject instanceof ResultSet rs ? trackResultSet( rs ) : driverObject;
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
@@ -245,7 +263,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public BigDecimal getBigDecimal(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getBigDecimal( parameterIndex );
+            return wrappedCallableStatement().getBigDecimal( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -256,7 +274,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Object getObject(int parameterIndex, Map<String, Class<?>> map) throws SQLException {
         try {
             verifyEnlistment();
-            Object driverObject = wrappedStatement.getObject( parameterIndex, map );
+            Object driverObject = wrappedCallableStatement().getObject( parameterIndex, map );
             return driverObject instanceof ResultSet rs ? trackResultSet( rs ) : driverObject;
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
@@ -268,7 +286,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Ref getRef(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getRef( parameterIndex );
+            return wrappedCallableStatement().getRef( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -279,7 +297,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Blob getBlob(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getBlob( parameterIndex );
+            return wrappedCallableStatement().getBlob( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -290,7 +308,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Clob getClob(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getClob( parameterIndex );
+            return wrappedCallableStatement().getClob( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -301,7 +319,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Array getArray(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getArray( parameterIndex );
+            return wrappedCallableStatement().getArray( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -312,7 +330,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Date getDate(int parameterIndex, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getDate( parameterIndex, cal );
+            return wrappedCallableStatement().getDate( parameterIndex, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -323,7 +341,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Time getTime(int parameterIndex, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getTime( parameterIndex, cal );
+            return wrappedCallableStatement().getTime( parameterIndex, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -334,7 +352,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Timestamp getTimestamp(int parameterIndex, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getTimestamp( parameterIndex, cal );
+            return wrappedCallableStatement().getTimestamp( parameterIndex, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -345,7 +363,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void registerOutParameter(int parameterIndex, int sqlType, String typeName) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.registerOutParameter( parameterIndex, sqlType, typeName );
+            wrappedCallableStatement().registerOutParameter( parameterIndex, sqlType, typeName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -356,7 +374,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void registerOutParameter(String parameterName, int sqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.registerOutParameter( parameterName, sqlType );
+            wrappedCallableStatement().registerOutParameter( parameterName, sqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -367,7 +385,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void registerOutParameter(String parameterName, int sqlType, int scale) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.registerOutParameter( parameterName, sqlType, scale );
+            wrappedCallableStatement().registerOutParameter( parameterName, sqlType, scale );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -378,7 +396,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void registerOutParameter(String parameterName, int sqlType, String typeName) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.registerOutParameter( parameterName, sqlType, typeName );
+            wrappedCallableStatement().registerOutParameter( parameterName, sqlType, typeName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -389,7 +407,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public URL getURL(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getURL( parameterIndex );
+            return wrappedCallableStatement().getURL( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -400,7 +418,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setURL(String parameterName, URL val) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setURL( parameterName, val );
+            wrappedCallableStatement().setURL( parameterName, val );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -411,7 +429,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNull(String parameterName, int sqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNull( parameterName, sqlType );
+            wrappedCallableStatement().setNull( parameterName, sqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -422,7 +440,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBoolean(String parameterName, boolean x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBoolean( parameterName, x );
+            wrappedCallableStatement().setBoolean( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -433,7 +451,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setByte(String parameterName, byte x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setByte( parameterName, x );
+            wrappedCallableStatement().setByte( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -444,7 +462,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setShort(String parameterName, short x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setShort( parameterName, x );
+            wrappedCallableStatement().setShort( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -455,7 +473,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setInt(String parameterName, int x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setInt( parameterName, x );
+            wrappedCallableStatement().setInt( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -466,7 +484,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setLong(String parameterName, long x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setLong( parameterName, x );
+            wrappedCallableStatement().setLong( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -477,7 +495,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setFloat(String parameterName, float x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setFloat( parameterName, x );
+            wrappedCallableStatement().setFloat( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -488,7 +506,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setDouble(String parameterName, double x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setDouble( parameterName, x );
+            wrappedCallableStatement().setDouble( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -499,7 +517,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBigDecimal(String parameterName, BigDecimal x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBigDecimal( parameterName, x );
+            wrappedCallableStatement().setBigDecimal( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -510,7 +528,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setString(String parameterName, String x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setString( parameterName, x );
+            wrappedCallableStatement().setString( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -521,7 +539,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBytes(String parameterName, byte[] x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBytes( parameterName, x );
+            wrappedCallableStatement().setBytes( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -532,7 +550,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setDate(String parameterName, Date x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setDate( parameterName, x );
+            wrappedCallableStatement().setDate( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -543,7 +561,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setTime(String parameterName, Time x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTime( parameterName, x );
+            wrappedCallableStatement().setTime( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -554,7 +572,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setTimestamp(String parameterName, Timestamp x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTimestamp( parameterName, x );
+            wrappedCallableStatement().setTimestamp( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -565,7 +583,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setAsciiStream(String parameterName, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setAsciiStream( parameterName, x, length );
+            wrappedCallableStatement().setAsciiStream( parameterName, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -576,7 +594,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBinaryStream(String parameterName, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBinaryStream( parameterName, x, length );
+            wrappedCallableStatement().setBinaryStream( parameterName, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -587,7 +605,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setObject(String parameterName, Object x, int targetSqlType, int scale) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterName, x, targetSqlType, scale );
+            wrappedCallableStatement().setObject( parameterName, x, targetSqlType, scale );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -598,7 +616,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setObject(String parameterName, Object x, int targetSqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterName, x, targetSqlType );
+            wrappedCallableStatement().setObject( parameterName, x, targetSqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -609,7 +627,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setObject(String parameterName, Object x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterName, x );
+            wrappedCallableStatement().setObject( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -620,7 +638,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setCharacterStream(String parameterName, Reader reader, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCharacterStream( parameterName, reader, length );
+            wrappedCallableStatement().setCharacterStream( parameterName, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -631,7 +649,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setDate(String parameterName, Date x, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setDate( parameterName, x, cal );
+            wrappedCallableStatement().setDate( parameterName, x, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -642,7 +660,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setTime(String parameterName, Time x, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTime( parameterName, x, cal );
+            wrappedCallableStatement().setTime( parameterName, x, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -653,7 +671,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setTimestamp(String parameterName, Timestamp x, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTimestamp( parameterName, x, cal );
+            wrappedCallableStatement().setTimestamp( parameterName, x, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -664,7 +682,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNull(String parameterName, int sqlType, String typeName) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNull( parameterName, sqlType, typeName );
+            wrappedCallableStatement().setNull( parameterName, sqlType, typeName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -675,7 +693,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public String getString(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getString( parameterName );
+            return wrappedCallableStatement().getString( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -686,7 +704,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public boolean getBoolean(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getBoolean( parameterName );
+            return wrappedCallableStatement().getBoolean( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -697,7 +715,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public byte getByte(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getByte( parameterName );
+            return wrappedCallableStatement().getByte( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -708,7 +726,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public short getShort(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getShort( parameterName );
+            return wrappedCallableStatement().getShort( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -719,7 +737,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public int getInt(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getInt( parameterName );
+            return wrappedCallableStatement().getInt( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -730,7 +748,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public long getLong(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getLong( parameterName );
+            return wrappedCallableStatement().getLong( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -741,7 +759,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public float getFloat(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getFloat( parameterName );
+            return wrappedCallableStatement().getFloat( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -752,7 +770,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public double getDouble(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getDouble( parameterName );
+            return wrappedCallableStatement().getDouble( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -763,7 +781,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public byte[] getBytes(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getBytes( parameterName );
+            return wrappedCallableStatement().getBytes( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -774,7 +792,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Date getDate(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getDate( parameterName );
+            return wrappedCallableStatement().getDate( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -785,7 +803,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Time getTime(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getTime( parameterName );
+            return wrappedCallableStatement().getTime( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -796,7 +814,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Timestamp getTimestamp(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getTimestamp( parameterName );
+            return wrappedCallableStatement().getTimestamp( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -807,7 +825,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Object getObject(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            Object driverObject = wrappedStatement.getObject( parameterName );
+            Object driverObject = wrappedCallableStatement().getObject( parameterName );
             return driverObject instanceof ResultSet rs ? trackResultSet( rs ) : driverObject;
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
@@ -819,7 +837,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public BigDecimal getBigDecimal(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getBigDecimal( parameterName );
+            return wrappedCallableStatement().getBigDecimal( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -830,7 +848,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Object getObject(String parameterName, Map<String, Class<?>> map) throws SQLException {
         try {
             verifyEnlistment();
-            Object driverObject = wrappedStatement.getObject( parameterName, map );
+            Object driverObject = wrappedCallableStatement().getObject( parameterName, map );
             return driverObject instanceof ResultSet rs ? trackResultSet( rs ) : driverObject;
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
@@ -842,7 +860,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Ref getRef(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getRef( parameterName );
+            return wrappedCallableStatement().getRef( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -853,7 +871,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Blob getBlob(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getBlob( parameterName );
+            return wrappedCallableStatement().getBlob( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -864,7 +882,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Clob getClob(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getClob( parameterName );
+            return wrappedCallableStatement().getClob( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -875,7 +893,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Array getArray(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getArray( parameterName );
+            return wrappedCallableStatement().getArray( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -886,7 +904,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Date getDate(String parameterName, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getDate( parameterName, cal );
+            return wrappedCallableStatement().getDate( parameterName, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -897,7 +915,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Time getTime(String parameterName, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getTime( parameterName, cal );
+            return wrappedCallableStatement().getTime( parameterName, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -908,7 +926,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Timestamp getTimestamp(String parameterName, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getTimestamp( parameterName, cal );
+            return wrappedCallableStatement().getTimestamp( parameterName, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -919,7 +937,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public URL getURL(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getURL( parameterName );
+            return wrappedCallableStatement().getURL( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -930,7 +948,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public RowId getRowId(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getRowId( parameterIndex );
+            return wrappedCallableStatement().getRowId( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -941,7 +959,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public RowId getRowId(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getRowId( parameterName );
+            return wrappedCallableStatement().getRowId( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -952,7 +970,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setRowId(String parameterName, RowId x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setRowId( parameterName, x );
+            wrappedCallableStatement().setRowId( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -963,7 +981,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNString(String parameterName, String value) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNString( parameterName, value );
+            wrappedCallableStatement().setNString( parameterName, value );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -974,7 +992,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNCharacterStream(String parameterName, Reader value, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNCharacterStream( parameterName, value, length );
+            wrappedCallableStatement().setNCharacterStream( parameterName, value, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -985,7 +1003,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNClob(String parameterName, NClob value) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNClob( parameterName, value );
+            wrappedCallableStatement().setNClob( parameterName, value );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -996,7 +1014,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setClob(String parameterName, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterName, reader, length );
+            wrappedCallableStatement().setClob( parameterName, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1007,7 +1025,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBlob(String parameterName, InputStream inputStream, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBlob( parameterName, inputStream, length );
+            wrappedCallableStatement().setBlob( parameterName, inputStream, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1018,7 +1036,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNClob(String parameterName, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNClob( parameterName, reader, length );
+            wrappedCallableStatement().setNClob( parameterName, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1029,7 +1047,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public NClob getNClob(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getNClob( parameterIndex );
+            return wrappedCallableStatement().getNClob( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1040,7 +1058,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public NClob getNClob(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getNClob( parameterName );
+            return wrappedCallableStatement().getNClob( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1051,7 +1069,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setSQLXML(String parameterName, SQLXML xmlObject) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setSQLXML( parameterName, xmlObject );
+            wrappedCallableStatement().setSQLXML( parameterName, xmlObject );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1062,7 +1080,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public SQLXML getSQLXML(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getSQLXML( parameterIndex );
+            return wrappedCallableStatement().getSQLXML( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1073,7 +1091,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public SQLXML getSQLXML(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getSQLXML( parameterName );
+            return wrappedCallableStatement().getSQLXML( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1084,7 +1102,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public String getNString(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getNString( parameterIndex );
+            return wrappedCallableStatement().getNString( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1095,7 +1113,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public String getNString(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getNString( parameterName );
+            return wrappedCallableStatement().getNString( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1106,7 +1124,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Reader getNCharacterStream(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getNCharacterStream( parameterIndex );
+            return wrappedCallableStatement().getNCharacterStream( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1117,7 +1135,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Reader getNCharacterStream(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getNCharacterStream( parameterName );
+            return wrappedCallableStatement().getNCharacterStream( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1128,7 +1146,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Reader getCharacterStream(int parameterIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getCharacterStream( parameterIndex );
+            return wrappedCallableStatement().getCharacterStream( parameterIndex );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1139,7 +1157,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public Reader getCharacterStream(String parameterName) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getCharacterStream( parameterName );
+            return wrappedCallableStatement().getCharacterStream( parameterName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1150,7 +1168,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBlob(String parameterName, Blob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBlob( parameterName, x );
+            wrappedCallableStatement().setBlob( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1161,7 +1179,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setClob(String parameterName, Clob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterName, x );
+            wrappedCallableStatement().setClob( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1172,7 +1190,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setAsciiStream(String parameterName, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setAsciiStream( parameterName, x, length );
+            wrappedCallableStatement().setAsciiStream( parameterName, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1183,7 +1201,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBinaryStream(String parameterName, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBinaryStream( parameterName, x, length );
+            wrappedCallableStatement().setBinaryStream( parameterName, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1194,7 +1212,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setCharacterStream(String parameterName, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCharacterStream( parameterName, reader, length );
+            wrappedCallableStatement().setCharacterStream( parameterName, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1205,7 +1223,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setAsciiStream(String parameterName, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setAsciiStream( parameterName, x );
+            wrappedCallableStatement().setAsciiStream( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1216,7 +1234,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBinaryStream(String parameterName, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBinaryStream( parameterName, x );
+            wrappedCallableStatement().setBinaryStream( parameterName, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1227,7 +1245,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setCharacterStream(String parameterName, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCharacterStream( parameterName, reader );
+            wrappedCallableStatement().setCharacterStream( parameterName, reader );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1238,7 +1256,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNCharacterStream(String parameterName, Reader value) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNCharacterStream( parameterName, value );
+            wrappedCallableStatement().setNCharacterStream( parameterName, value );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1249,7 +1267,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setClob(String parameterName, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterName, reader );
+            wrappedCallableStatement().setClob( parameterName, reader );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1260,7 +1278,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBlob(String parameterName, InputStream inputStream) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBlob( parameterName, inputStream );
+            wrappedCallableStatement().setBlob( parameterName, inputStream );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1271,7 +1289,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNClob(String parameterName, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterName, reader );
+            wrappedCallableStatement().setClob( parameterName, reader );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1283,7 +1301,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException {
         try {
             verifyEnlistment();
-            T driverObject = wrappedStatement.getObject( parameterIndex, type );
+            T driverObject = wrappedCallableStatement().getObject( parameterIndex, type );
             return driverObject instanceof ResultSet rs ? (T) trackResultSet( rs ) : driverObject;
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
@@ -1296,7 +1314,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public <T> T getObject(String parameterName, Class<T> type) throws SQLException {
         try {
             verifyEnlistment();
-            T driverObject = wrappedStatement.getObject( parameterName, type );
+            T driverObject = wrappedCallableStatement().getObject( parameterName, type );
             return driverObject instanceof ResultSet rs ? (T) trackResultSet( rs ) : driverObject;
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
@@ -1308,7 +1326,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public ResultSet executeQuery() throws SQLException {
         try {
             verifyEnlistment();
-            return trackResultSet( wrappedStatement.executeQuery() );
+            return trackResultSet( wrappedCallableStatement().executeQuery() );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1319,7 +1337,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public int executeUpdate() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeUpdate();
+            return wrappedCallableStatement().executeUpdate();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1330,7 +1348,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNull(int parameterIndex, int sqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNull( parameterIndex, sqlType );
+            wrappedCallableStatement().setNull( parameterIndex, sqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1341,7 +1359,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBoolean(int parameterIndex, boolean x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBoolean( parameterIndex, x );
+            wrappedCallableStatement().setBoolean( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1352,7 +1370,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setByte(int parameterIndex, byte x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setByte( parameterIndex, x );
+            wrappedCallableStatement().setByte( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1363,7 +1381,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setShort(int parameterIndex, short x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setShort( parameterIndex, x );
+            wrappedCallableStatement().setShort( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1374,7 +1392,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setInt(int parameterIndex, int x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setInt( parameterIndex, x );
+            wrappedCallableStatement().setInt( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1385,7 +1403,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setLong(int parameterIndex, long x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setLong( parameterIndex, x );
+            wrappedCallableStatement().setLong( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1396,7 +1414,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setFloat(int parameterIndex, float x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setFloat( parameterIndex, x );
+            wrappedCallableStatement().setFloat( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1407,7 +1425,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setDouble(int parameterIndex, double x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setDouble( parameterIndex, x );
+            wrappedCallableStatement().setDouble( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1418,7 +1436,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBigDecimal( parameterIndex, x );
+            wrappedCallableStatement().setBigDecimal( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1429,7 +1447,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setString(int parameterIndex, String x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setString( parameterIndex, x );
+            wrappedCallableStatement().setString( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1440,7 +1458,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBytes(int parameterIndex, byte[] x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBytes( parameterIndex, x );
+            wrappedCallableStatement().setBytes( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1451,7 +1469,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setDate(int parameterIndex, Date x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setDate( parameterIndex, x );
+            wrappedCallableStatement().setDate( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1462,7 +1480,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setTime(int parameterIndex, Time x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTime( parameterIndex, x );
+            wrappedCallableStatement().setTime( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1473,7 +1491,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTimestamp( parameterIndex, x );
+            wrappedCallableStatement().setTimestamp( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1484,7 +1502,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setAsciiStream( parameterIndex, x, length );
+            wrappedCallableStatement().setAsciiStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1496,7 +1514,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setUnicodeStream( parameterIndex, x, length );
+            wrappedCallableStatement().setUnicodeStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1507,7 +1525,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBinaryStream( parameterIndex, x, length );
+            wrappedCallableStatement().setBinaryStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1518,7 +1536,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void clearParameters() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.clearParameters();
+            wrappedCallableStatement().clearParameters();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1529,7 +1547,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x, targetSqlType );
+            wrappedCallableStatement().setObject( parameterIndex, x, targetSqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1540,7 +1558,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x );
+            wrappedCallableStatement().setObject( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1551,7 +1569,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public boolean execute() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.execute();
+            return wrappedCallableStatement().execute();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1562,7 +1580,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void addBatch() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.addBatch();
+            wrappedCallableStatement().addBatch();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1573,7 +1591,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCharacterStream( parameterIndex, reader, length );
+            wrappedCallableStatement().setCharacterStream( parameterIndex, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1584,7 +1602,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setRef(int parameterIndex, Ref x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setRef( parameterIndex, x );
+            wrappedCallableStatement().setRef( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1595,7 +1613,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBlob(int parameterIndex, Blob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBlob( parameterIndex, x );
+            wrappedCallableStatement().setBlob( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1606,7 +1624,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setClob(int parameterIndex, Clob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterIndex, x );
+            wrappedCallableStatement().setClob( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1617,7 +1635,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setArray(int parameterIndex, Array x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setArray( parameterIndex, x );
+            wrappedCallableStatement().setArray( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1628,7 +1646,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public ResultSetMetaData getMetaData() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getMetaData();
+            return wrappedCallableStatement().getMetaData();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1639,7 +1657,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setDate( parameterIndex, x, cal );
+            wrappedCallableStatement().setDate( parameterIndex, x, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1650,7 +1668,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTime( parameterIndex, x, cal );
+            wrappedCallableStatement().setTime( parameterIndex, x, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1661,7 +1679,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTimestamp( parameterIndex, x, cal );
+            wrappedCallableStatement().setTimestamp( parameterIndex, x, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1672,7 +1690,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNull( parameterIndex, sqlType, typeName );
+            wrappedCallableStatement().setNull( parameterIndex, sqlType, typeName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1683,7 +1701,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setURL(int parameterIndex, URL x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setURL( parameterIndex, x );
+            wrappedCallableStatement().setURL( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1694,7 +1712,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public ParameterMetaData getParameterMetaData() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getParameterMetaData();
+            return wrappedCallableStatement().getParameterMetaData();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1705,7 +1723,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setRowId(int parameterIndex, RowId x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setRowId( parameterIndex, x );
+            wrappedCallableStatement().setRowId( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1716,7 +1734,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNString(int parameterIndex, String value) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNString( parameterIndex, value );
+            wrappedCallableStatement().setNString( parameterIndex, value );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1727,7 +1745,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNCharacterStream( parameterIndex, value, length );
+            wrappedCallableStatement().setNCharacterStream( parameterIndex, value, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1738,7 +1756,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNClob(int parameterIndex, NClob value) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNClob( parameterIndex, value );
+            wrappedCallableStatement().setNClob( parameterIndex, value );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1749,7 +1767,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterIndex, reader, length );
+            wrappedCallableStatement().setClob( parameterIndex, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1760,7 +1778,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBlob( parameterIndex, inputStream, length );
+            wrappedCallableStatement().setBlob( parameterIndex, inputStream, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1771,7 +1789,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNClob( parameterIndex, reader, length );
+            wrappedCallableStatement().setNClob( parameterIndex, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1782,7 +1800,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setSQLXML( parameterIndex, xmlObject );
+            wrappedCallableStatement().setSQLXML( parameterIndex, xmlObject );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1793,7 +1811,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x, targetSqlType, scaleOrLength );
+            wrappedCallableStatement().setObject( parameterIndex, x, targetSqlType, scaleOrLength );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1804,7 +1822,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setAsciiStream( parameterIndex, x, length );
+            wrappedCallableStatement().setAsciiStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1815,7 +1833,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBinaryStream( parameterIndex, x, length );
+            wrappedCallableStatement().setBinaryStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1826,7 +1844,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCharacterStream( parameterIndex, reader, length );
+            wrappedCallableStatement().setCharacterStream( parameterIndex, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1837,7 +1855,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setAsciiStream( parameterIndex, x );
+            wrappedCallableStatement().setAsciiStream( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1848,7 +1866,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBinaryStream( parameterIndex, x );
+            wrappedCallableStatement().setBinaryStream( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1859,7 +1877,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCharacterStream( parameterIndex, reader );
+            wrappedCallableStatement().setCharacterStream( parameterIndex, reader );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1870,7 +1888,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNCharacterStream( parameterIndex, value );
+            wrappedCallableStatement().setNCharacterStream( parameterIndex, value );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1881,7 +1899,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setClob(int parameterIndex, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterIndex, reader );
+            wrappedCallableStatement().setClob( parameterIndex, reader );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1892,7 +1910,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBlob( parameterIndex, inputStream );
+            wrappedCallableStatement().setBlob( parameterIndex, inputStream );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1903,7 +1921,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setNClob(int parameterIndex, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNClob( parameterIndex, reader );
+            wrappedCallableStatement().setNClob( parameterIndex, reader );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1916,7 +1934,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x, targetSqlType, scaleOrLength );
+            wrappedCallableStatement().setObject( parameterIndex, x, targetSqlType, scaleOrLength );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1927,7 +1945,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x, targetSqlType );
+            wrappedCallableStatement().setObject( parameterIndex, x, targetSqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -1938,7 +1956,7 @@ public final class CallableStatementWrapper extends StatementWrapper implements 
     public long executeLargeUpdate() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeLargeUpdate();
+            return wrappedCallableStatement().executeLargeUpdate();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
@@ -25,6 +25,8 @@ import java.sql.Struct;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.concurrent.Executor;
 
 import static java.sql.ClientInfoStatus.REASON_UNKNOWN;
@@ -37,6 +39,20 @@ import static java.util.stream.Collectors.toMap;
  * @author <a href="jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
 public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrapper> implements Connection {
+
+    private static final VarHandle WRAPPED;
+
+    static {
+        try {
+            WRAPPED = MethodHandles.lookup().findVarHandle( ConnectionWrapper.class, "wrappedConnection", Connection.class );
+        } catch ( NoSuchFieldException | IllegalAccessException e ) {
+            throw new ExceptionInInitializerError( e );
+        }
+    }
+
+    private Connection wrappedConnection() {
+        return (Connection) WRAPPED.getAcquire( this );
+    }
 
     // --- //
 
@@ -69,7 +85,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
     private ConnectionWrapper(ConnectionHandler connectionHandler, boolean trackResources, AutoCloseableElement<ConnectionWrapper> head, boolean detached, boolean defaultHold) {
         super( head );
         handler = connectionHandler;
-        wrappedConnection = connectionHandler.rawConnection();
+        WRAPPED.setRelease( this, connectionHandler.rawConnection() );
         trackedStatements = trackResources ? newHead() : null;
         detachedState = detached;
         holdState = defaultHold;
@@ -137,8 +153,8 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
     @Override
     public void close() throws SQLException {
         handler.traceConnectionOperation( "close()" );
-        if ( wrappedConnection != ClosedConnection.INSTANCE ) {
-            wrappedConnection = ClosedConnection.INSTANCE;
+        if ( wrappedConnection() != ClosedConnection.INSTANCE ) {
+            WRAPPED.setRelease( this, ClosedConnection.INSTANCE );
             pruneClosed();
             if ( trackedStatements != null ) {
                 addLeakedStatements( trackedStatements.closeAllAutocloseableElements() );
@@ -151,8 +167,9 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
     public void abort(Executor executor) throws SQLException {
         handler.traceConnectionOperation( "abort()" );
         try {
-            wrappedConnection = ClosedConnection.INSTANCE;
-            wrappedConnection.abort( executor );
+            Connection connection = wrappedConnection();
+            WRAPPED.setRelease( this, ClosedConnection.INSTANCE );
+            connection.abort( executor );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -168,9 +185,9 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         }
         try {
             verifyEnlistment();
-            if ( wrappedConnection.getAutoCommit() != autoCommit ) {
+            if ( wrappedConnection().getAutoCommit() != autoCommit ) {
                 handler.setDirtyAttribute( ConnectionHandler.DirtyAttribute.AUTOCOMMIT );
-                wrappedConnection.setAutoCommit( autoCommit );
+                wrappedConnection().setAutoCommit( autoCommit );
             }
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
@@ -183,7 +200,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getAutoCommit()" );
             verifyEnlistment();
-            return wrappedConnection.getAutoCommit();
+            return wrappedConnection().getAutoCommit();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -198,7 +215,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
             throw new SQLException( "Attempting to commit while taking part in a transaction" );
         }
         try {
-            wrappedConnection.commit();
+            wrappedConnection().commit();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -214,7 +231,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         }
         try {
             verifyEnlistment();
-            wrappedConnection.rollback();
+            wrappedConnection().rollback();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -230,7 +247,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         }
         try {
             verifyEnlistment();
-            wrappedConnection.rollback( savepoint );
+            wrappedConnection().rollback( savepoint );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -244,7 +261,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "clearWarnings()" );
             verifyEnlistment();
-            wrappedConnection.clearWarnings();
+            wrappedConnection().clearWarnings();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -256,7 +273,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "createClob()" );
             verifyEnlistment();
-            return wrappedConnection.createClob();
+            return wrappedConnection().createClob();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -268,7 +285,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "createBlob()" );
             verifyEnlistment();
-            return wrappedConnection.createBlob();
+            return wrappedConnection().createBlob();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -280,7 +297,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "createNClob()" );
             verifyEnlistment();
-            return wrappedConnection.createNClob();
+            return wrappedConnection().createNClob();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -292,7 +309,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "createSQLXML()" );
             verifyEnlistment();
-            return wrappedConnection.createSQLXML();
+            return wrappedConnection().createSQLXML();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -304,7 +321,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "createArrayOf(String, Object[])" );
             verifyEnlistment();
-            return wrappedConnection.createArrayOf( typeName, elements );
+            return wrappedConnection().createArrayOf( typeName, elements );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -316,7 +333,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "createStatement()" );
             verifyEnlistment();
-            return trackStatement( wrappedConnection.createStatement() );
+            return trackStatement( wrappedConnection().createStatement() );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -328,7 +345,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "createStatement(int, int)" );
             verifyEnlistment();
-            return trackStatement( wrappedConnection.createStatement( resultSetType, resultSetConcurrency ) );
+            return trackStatement( wrappedConnection().createStatement( resultSetType, resultSetConcurrency ) );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -340,7 +357,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "createStatement(int, int, int)" );
             verifyEnlistment();
-            return trackStatement( wrappedConnection.createStatement( resultSetType, resultSetConcurrency, resultSetHoldability ), resultSetHoldability == HOLD_CURSORS_OVER_COMMIT );
+            return trackStatement( wrappedConnection().createStatement( resultSetType, resultSetConcurrency, resultSetHoldability ), resultSetHoldability == HOLD_CURSORS_OVER_COMMIT );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -352,7 +369,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "createStruct(String, Object[])" );
             verifyEnlistment();
-            return wrappedConnection.createStruct( typeName, attributes );
+            return wrappedConnection().createStruct( typeName, attributes );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -364,7 +381,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getCatalog()" );
             verifyEnlistment();
-            return wrappedConnection.getCatalog();
+            return wrappedConnection().getCatalog();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -377,7 +394,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
             handler.traceConnectionOperation( "setCatalog(String)" );
             verifyEnlistment();
             handler.setDirtyAttribute( ConnectionHandler.DirtyAttribute.CATALOG );
-            wrappedConnection.setCatalog( catalog );
+            wrappedConnection().setCatalog( catalog );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -389,7 +406,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getHoldability()" );
             verifyEnlistment();
-            return wrappedConnection.getHoldability();
+            return wrappedConnection().getHoldability();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -403,7 +420,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
             verifyEnlistment();
             handler.setDirtyAttribute( ConnectionHandler.DirtyAttribute.HOLDABILITY );
             holdState = ( holdability == HOLD_CURSORS_OVER_COMMIT );
-            wrappedConnection.setHoldability( holdability );
+            wrappedConnection().setHoldability( holdability );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -415,7 +432,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getClientInfo()" );
             verifyEnlistment();
-            return wrappedConnection.getClientInfo();
+            return wrappedConnection().getClientInfo();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -427,7 +444,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "setClientInfo(Properties)" );
             verifyEnlistment();
-            wrappedConnection.setClientInfo( properties );
+            wrappedConnection().setClientInfo( properties );
         } catch ( SQLClientInfoException sce ) {
             handler.setFlushOnly( sce );
             throw sce;
@@ -442,7 +459,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getClientInfo(String)" );
             verifyEnlistment();
-            return wrappedConnection.getClientInfo( name );
+            return wrappedConnection().getClientInfo( name );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -454,7 +471,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getMetaData()" );
             verifyEnlistment();
-            return wrappedConnection.getMetaData();
+            return wrappedConnection().getMetaData();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -466,7 +483,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getNetworkTimeout()" );
             verifyEnlistment();
-            return wrappedConnection.getNetworkTimeout();
+            return wrappedConnection().getNetworkTimeout();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -478,7 +495,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getSchema()" );
             verifyEnlistment();
-            return wrappedConnection.getSchema();
+            return wrappedConnection().getSchema();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -491,7 +508,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
             handler.traceConnectionOperation( "setSchema(String)" );
             verifyEnlistment();
             handler.setDirtyAttribute( ConnectionHandler.DirtyAttribute.SCHEMA );
-            wrappedConnection.setSchema( schema );
+            wrappedConnection().setSchema( schema );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -503,7 +520,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getTypeMap()" );
             verifyEnlistment();
-            return wrappedConnection.getTypeMap();
+            return wrappedConnection().getTypeMap();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -515,7 +532,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "setTypeMap(Map<String, Class<?>>)" );
             verifyEnlistment();
-            wrappedConnection.setTypeMap( map );
+            wrappedConnection().setTypeMap( map );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -527,7 +544,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getTransactionIsolation()" );
             verifyEnlistment();
-            return wrappedConnection.getTransactionIsolation();
+            return wrappedConnection().getTransactionIsolation();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -540,7 +557,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
             handler.traceConnectionOperation( "setTransactionIsolation(int)" );
             verifyEnlistment();
             handler.setDirtyAttribute( ConnectionHandler.DirtyAttribute.TRANSACTION_ISOLATION );
-            wrappedConnection.setTransactionIsolation( level );
+            wrappedConnection().setTransactionIsolation( level );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -552,7 +569,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "getWarnings()" );
             verifyEnlistment();
-            return wrappedConnection.getWarnings();
+            return wrappedConnection().getWarnings();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -563,7 +580,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
     public boolean isClosed() throws SQLException {
         try {
             handler.traceConnectionOperation( "isClosed()" );
-            return wrappedConnection.isClosed();
+            return wrappedConnection().isClosed();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -575,7 +592,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "isReadOnly()" );
             verifyEnlistment();
-            return wrappedConnection.isReadOnly();
+            return wrappedConnection().isReadOnly();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -589,7 +606,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
             handler.verifyReadOnly( readOnly );
             verifyEnlistment();
             handler.setDirtyAttribute( ConnectionHandler.DirtyAttribute.READ_ONLY );
-            wrappedConnection.setReadOnly( readOnly );
+            wrappedConnection().setReadOnly( readOnly );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -601,7 +618,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "isValid(int)" );
             verifyEnlistment();
-            return wrappedConnection.isValid( timeout );
+            return wrappedConnection().isValid( timeout );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -613,7 +630,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "nativeSQL(String)" );
             verifyEnlistment();
-            return wrappedConnection.nativeSQL( sql );
+            return wrappedConnection().nativeSQL( sql );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -625,7 +642,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "prepareCall(String)" );
             verifyEnlistment();
-            return trackCallableStatement( wrappedConnection.prepareCall( sql ) );
+            return trackCallableStatement( wrappedConnection().prepareCall( sql ) );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -637,7 +654,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "prepareCall(String, int, int)" );
             verifyEnlistment();
-            return trackCallableStatement( wrappedConnection.prepareCall( sql, resultSetType, resultSetConcurrency ) );
+            return trackCallableStatement( wrappedConnection().prepareCall( sql, resultSetType, resultSetConcurrency ) );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -649,7 +666,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "prepareCall(String, int, int, int)" );
             verifyEnlistment();
-            return trackCallableStatement( wrappedConnection.prepareCall( sql, resultSetType, resultSetConcurrency, resultSetHoldability ), resultSetHoldability == HOLD_CURSORS_OVER_COMMIT );
+            return trackCallableStatement( wrappedConnection().prepareCall( sql, resultSetType, resultSetConcurrency, resultSetHoldability ), resultSetHoldability == HOLD_CURSORS_OVER_COMMIT );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -661,7 +678,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "prepareStatement(String)" );
             verifyEnlistment();
-            return trackPreparedStatement( wrappedConnection.prepareStatement( sql ) );
+            return trackPreparedStatement( wrappedConnection().prepareStatement( sql ) );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -673,7 +690,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "prepareStatement(String, int, int)" );
             verifyEnlistment();
-            return trackPreparedStatement( wrappedConnection.prepareStatement( sql, resultSetType, resultSetConcurrency ) );
+            return trackPreparedStatement( wrappedConnection().prepareStatement( sql, resultSetType, resultSetConcurrency ) );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -685,7 +702,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "prepareStatement(String, int, int, int)" );
             verifyEnlistment();
-            return trackPreparedStatement( wrappedConnection.prepareStatement( sql, resultSetType, resultSetConcurrency, resultSetHoldability ), resultSetHoldability == HOLD_CURSORS_OVER_COMMIT );
+            return trackPreparedStatement( wrappedConnection().prepareStatement( sql, resultSetType, resultSetConcurrency, resultSetHoldability ), resultSetHoldability == HOLD_CURSORS_OVER_COMMIT );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -697,7 +714,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "prepareStatement(String, int)" );
             verifyEnlistment();
-            return trackPreparedStatement( wrappedConnection.prepareStatement( sql, autoGeneratedKeys ) );
+            return trackPreparedStatement( wrappedConnection().prepareStatement( sql, autoGeneratedKeys ) );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -709,7 +726,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "prepareStatement(String, int[])" );
             verifyEnlistment();
-            return trackPreparedStatement( wrappedConnection.prepareStatement( sql, columnIndexes ) );
+            return trackPreparedStatement( wrappedConnection().prepareStatement( sql, columnIndexes ) );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -721,7 +738,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "prepareStatement(String, String[])" );
             verifyEnlistment();
-            return trackPreparedStatement( wrappedConnection.prepareStatement( sql, columnNames ) );
+            return trackPreparedStatement( wrappedConnection().prepareStatement( sql, columnNames ) );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -733,7 +750,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "releaseSavepoint(Savepoint)" );
             verifyEnlistment();
-            wrappedConnection.releaseSavepoint( savepoint );
+            wrappedConnection().releaseSavepoint( savepoint );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -745,7 +762,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "setClientInfo(String, String)" );
             verifyEnlistment();
-            wrappedConnection.setClientInfo( name, value );
+            wrappedConnection().setClientInfo( name, value );
         } catch ( SQLClientInfoException sce ) {
             handler.setFlushOnly( sce );
             throw sce;
@@ -760,7 +777,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "setSavepoint()" );
             verifyEnlistment();
-            return wrappedConnection.setSavepoint();
+            return wrappedConnection().setSavepoint();
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -772,7 +789,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         try {
             handler.traceConnectionOperation( "setSavepoint(String)" );
             verifyEnlistment();
-            return wrappedConnection.setSavepoint( name );
+            return wrappedConnection().setSavepoint( name );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -785,7 +802,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
             handler.traceConnectionOperation( "setNetworkTimeout(Executor, int)" );
             verifyEnlistment();
             handler.setDirtyAttribute( ConnectionHandler.DirtyAttribute.NETWORK_TIMEOUT );
-            wrappedConnection.setNetworkTimeout( executor, milliseconds );
+            wrappedConnection().setNetworkTimeout( executor, milliseconds );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -799,7 +816,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
     public <T> T unwrap(Class<T> target) throws SQLException {
         try {
             handler.traceConnectionOperation( "unwrap(Class<T>)" );
-            return wrappedConnection.unwrap( target );
+            return wrappedConnection().unwrap( target );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -810,7 +827,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
     public boolean isWrapperFor(Class<?> target) throws SQLException {
         try {
             handler.traceConnectionOperation( "isWrapperFor(Class<?>)" );
-            return wrappedConnection.isWrapperFor( target );
+            return wrappedConnection().isWrapperFor( target );
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
@@ -819,7 +836,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
 
     @Override
     public String toString() {
-        return "wrapped[" + wrappedConnection + ( handler.isEnlisted() ? "]<<enrolled" : "]" );
+        return "wrapped[" + wrappedConnection() + ( handler.isEnlisted() ? "]<<enrolled" : "]" );
     }
 
     public void addLeakedStatements(int leaks) {
@@ -856,7 +873,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
 
     @Override
     protected boolean internalClosed() {
-        return wrappedConnection == ClosedConnection.INSTANCE;
+        return wrappedConnection() == ClosedConnection.INSTANCE;
     }
 
 }

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/PreparedStatementWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/PreparedStatementWrapper.java
@@ -8,6 +8,8 @@ import io.agroal.pool.wrapper.closed.ClosedPreparedStatement;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
@@ -32,20 +34,36 @@ import java.util.Calendar;
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
  * @author <a href="jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
+@SuppressWarnings( "resource" )
 public final class PreparedStatementWrapper extends StatementWrapper implements PreparedStatement {
+
+    private static final VarHandle WRAPPED;
+
+    static {
+        try {
+            WRAPPED = MethodHandles.lookup().findVarHandle( PreparedStatementWrapper.class, "wrappedStatement", PreparedStatement.class );
+        } catch ( NoSuchFieldException | IllegalAccessException e ) {
+            throw new ExceptionInInitializerError( e );
+        }
+    }
+
+    private PreparedStatement wrappedPreparedStatement() {
+        return (PreparedStatement) WRAPPED.getAcquire( this );
+    }
 
     // --- //
 
+    @SuppressWarnings( "unused" )
     private PreparedStatement wrappedStatement;
 
     public PreparedStatementWrapper(ConnectionWrapper connectionWrapper, PreparedStatement statement, boolean trackJdbcResources, AutoCloseableElement head, boolean defaultHoldability) {
         super( connectionWrapper, statement, trackJdbcResources, head, defaultHoldability );
-        wrappedStatement = statement;
+        WRAPPED.setRelease( this, statement );
     }
 
     @Override
     public void close() throws SQLException {
-        wrappedStatement = ClosedPreparedStatement.INSTANCE;
+        WRAPPED.setRelease( this, ClosedPreparedStatement.INSTANCE );
         super.close();
     }
 
@@ -55,7 +73,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public ResultSet executeQuery() throws SQLException {
         try {
             verifyEnlistment();
-            return trackResultSet( wrappedStatement.executeQuery() );
+            return trackResultSet( wrappedPreparedStatement().executeQuery() );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -66,7 +84,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public int executeUpdate() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeUpdate();
+            return wrappedPreparedStatement().executeUpdate();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -77,7 +95,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setNull(int parameterIndex, int sqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNull( parameterIndex, sqlType );
+            wrappedPreparedStatement().setNull( parameterIndex, sqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -88,7 +106,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setBoolean(int parameterIndex, boolean x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBoolean( parameterIndex, x );
+            wrappedPreparedStatement().setBoolean( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -99,7 +117,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setByte(int parameterIndex, byte x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setByte( parameterIndex, x );
+            wrappedPreparedStatement().setByte( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -110,7 +128,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setShort(int parameterIndex, short x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setShort( parameterIndex, x );
+            wrappedPreparedStatement().setShort( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -121,7 +139,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setInt(int parameterIndex, int x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setInt( parameterIndex, x );
+            wrappedPreparedStatement().setInt( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -132,7 +150,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setLong(int parameterIndex, long x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setLong( parameterIndex, x );
+            wrappedPreparedStatement().setLong( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -143,7 +161,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setFloat(int parameterIndex, float x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setFloat( parameterIndex, x );
+            wrappedPreparedStatement().setFloat( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -154,7 +172,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setDouble(int parameterIndex, double x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setDouble( parameterIndex, x );
+            wrappedPreparedStatement().setDouble( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -165,7 +183,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBigDecimal( parameterIndex, x );
+            wrappedPreparedStatement().setBigDecimal( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -176,7 +194,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setString(int parameterIndex, String x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setString( parameterIndex, x );
+            wrappedPreparedStatement().setString( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -187,7 +205,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setBytes(int parameterIndex, byte[] x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBytes( parameterIndex, x );
+            wrappedPreparedStatement().setBytes( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -198,7 +216,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setDate(int parameterIndex, Date x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setDate( parameterIndex, x );
+            wrappedPreparedStatement().setDate( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -209,7 +227,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setTime(int parameterIndex, Time x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTime( parameterIndex, x );
+            wrappedPreparedStatement().setTime( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -220,7 +238,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTimestamp( parameterIndex, x );
+            wrappedPreparedStatement().setTimestamp( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -231,7 +249,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setAsciiStream( parameterIndex, x, length );
+            wrappedPreparedStatement().setAsciiStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -243,7 +261,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setUnicodeStream( parameterIndex, x, length );
+            wrappedPreparedStatement().setUnicodeStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -254,7 +272,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBinaryStream( parameterIndex, x, length );
+            wrappedPreparedStatement().setBinaryStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -265,7 +283,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void clearParameters() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.clearParameters();
+            wrappedPreparedStatement().clearParameters();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -276,7 +294,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x, targetSqlType );
+            wrappedPreparedStatement().setObject( parameterIndex, x, targetSqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -287,7 +305,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x );
+            wrappedPreparedStatement().setObject( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -298,7 +316,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public boolean execute() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.execute();
+            return wrappedPreparedStatement().execute();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -309,7 +327,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void addBatch() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.addBatch();
+            wrappedPreparedStatement().addBatch();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -320,7 +338,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCharacterStream( parameterIndex, reader, length );
+            wrappedPreparedStatement().setCharacterStream( parameterIndex, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -331,7 +349,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setRef(int parameterIndex, Ref x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setRef( parameterIndex, x );
+            wrappedPreparedStatement().setRef( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -342,7 +360,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setBlob(int parameterIndex, Blob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBlob( parameterIndex, x );
+            wrappedPreparedStatement().setBlob( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -353,7 +371,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setClob(int parameterIndex, Clob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterIndex, x );
+            wrappedPreparedStatement().setClob( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -364,7 +382,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setArray(int parameterIndex, Array x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setArray( parameterIndex, x );
+            wrappedPreparedStatement().setArray( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -375,7 +393,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public ResultSetMetaData getMetaData() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getMetaData();
+            return wrappedPreparedStatement().getMetaData();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -386,7 +404,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setDate( parameterIndex, x, cal );
+            wrappedPreparedStatement().setDate( parameterIndex, x, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -397,7 +415,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTime( parameterIndex, x, cal );
+            wrappedPreparedStatement().setTime( parameterIndex, x, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -408,7 +426,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setTimestamp( parameterIndex, x, cal );
+            wrappedPreparedStatement().setTimestamp( parameterIndex, x, cal );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -419,7 +437,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNull( parameterIndex, sqlType, typeName );
+            wrappedPreparedStatement().setNull( parameterIndex, sqlType, typeName );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -430,7 +448,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setURL(int parameterIndex, URL x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setURL( parameterIndex, x );
+            wrappedPreparedStatement().setURL( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -441,7 +459,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public ParameterMetaData getParameterMetaData() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getParameterMetaData();
+            return wrappedPreparedStatement().getParameterMetaData();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -452,7 +470,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setRowId(int parameterIndex, RowId x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setRowId( parameterIndex, x );
+            wrappedPreparedStatement().setRowId( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -463,7 +481,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setNString(int parameterIndex, String value) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNString( parameterIndex, value );
+            wrappedPreparedStatement().setNString( parameterIndex, value );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -474,7 +492,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNCharacterStream( parameterIndex, value, length );
+            wrappedPreparedStatement().setNCharacterStream( parameterIndex, value, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -485,7 +503,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setNClob(int parameterIndex, NClob value) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNClob( parameterIndex, value );
+            wrappedPreparedStatement().setNClob( parameterIndex, value );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -496,7 +514,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterIndex, reader, length );
+            wrappedPreparedStatement().setClob( parameterIndex, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -507,7 +525,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBlob( parameterIndex, inputStream, length );
+            wrappedPreparedStatement().setBlob( parameterIndex, inputStream, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -518,7 +536,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNClob( parameterIndex, reader, length );
+            wrappedPreparedStatement().setNClob( parameterIndex, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -529,7 +547,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setSQLXML( parameterIndex, xmlObject );
+            wrappedPreparedStatement().setSQLXML( parameterIndex, xmlObject );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -540,7 +558,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x, targetSqlType, scaleOrLength );
+            wrappedPreparedStatement().setObject( parameterIndex, x, targetSqlType, scaleOrLength );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -551,7 +569,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setAsciiStream( parameterIndex, x, length );
+            wrappedPreparedStatement().setAsciiStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -562,7 +580,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBinaryStream( parameterIndex, x, length );
+            wrappedPreparedStatement().setBinaryStream( parameterIndex, x, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -573,7 +591,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCharacterStream( parameterIndex, reader, length );
+            wrappedPreparedStatement().setCharacterStream( parameterIndex, reader, length );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -584,7 +602,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setAsciiStream( parameterIndex, x );
+            wrappedPreparedStatement().setAsciiStream( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -595,7 +613,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBinaryStream( parameterIndex, x );
+            wrappedPreparedStatement().setBinaryStream( parameterIndex, x );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -606,7 +624,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCharacterStream( parameterIndex, reader );
+            wrappedPreparedStatement().setCharacterStream( parameterIndex, reader );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -617,7 +635,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNCharacterStream( parameterIndex, value );
+            wrappedPreparedStatement().setNCharacterStream( parameterIndex, value );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -628,7 +646,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setClob(int parameterIndex, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setClob( parameterIndex, reader );
+            wrappedPreparedStatement().setClob( parameterIndex, reader );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -639,7 +657,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setBlob( parameterIndex, inputStream );
+            wrappedPreparedStatement().setBlob( parameterIndex, inputStream );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -650,7 +668,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setNClob(int parameterIndex, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setNClob( parameterIndex, reader );
+            wrappedPreparedStatement().setNClob( parameterIndex, reader );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -663,7 +681,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x, targetSqlType, scaleOrLength );
+            wrappedPreparedStatement().setObject( parameterIndex, x, targetSqlType, scaleOrLength );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -674,7 +692,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setObject( parameterIndex, x, targetSqlType );
+            wrappedPreparedStatement().setObject( parameterIndex, x, targetSqlType );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -685,7 +703,7 @@ public final class PreparedStatementWrapper extends StatementWrapper implements 
     public long executeLargeUpdate() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeLargeUpdate();
+            return wrappedPreparedStatement().executeLargeUpdate();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/ResultSetWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/ResultSetWrapper.java
@@ -8,6 +8,8 @@ import io.agroal.pool.wrapper.closed.ClosedResultSet;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
@@ -33,33 +35,49 @@ import java.util.Map;
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
  * @author <a href="jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
+@SuppressWarnings( "resource" )
 public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrapper> implements ResultSet {
+
+    private static final VarHandle WRAPPED;
+
+    static {
+        try {
+            WRAPPED = MethodHandles.lookup().findVarHandle( ResultSetWrapper.class, "wrappedResultSet", ResultSet.class );
+        } catch ( NoSuchFieldException | IllegalAccessException e ) {
+            throw new ExceptionInInitializerError( e );
+        }
+    }
+
+    private ResultSet wrappedResultSet() {
+        return (ResultSet) WRAPPED.getAcquire( this );
+    }
 
     // --- //
 
     private final StatementWrapper statement;
 
+    @SuppressWarnings( "unused" )
     private ResultSet wrappedResultSet;
 
     public ResultSetWrapper(StatementWrapper statementWrapper, ResultSet resultSet, AutoCloseableElement<ResultSetWrapper> head, boolean defaultHold) {
         super( head );
         statement = statementWrapper;
-        wrappedResultSet = resultSet;
+        WRAPPED.setRelease( this, resultSet );
     }
-    
+
     private void verifyEnlistment() throws SQLException {
         statement.verifyEnlistment();
     }
-    
+
     @Override
     public void close() throws SQLException {
         try {
-            wrappedResultSet.close();
+            wrappedResultSet().close();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
         } finally {
-            wrappedResultSet = ClosedResultSet.INSTANCE;
+            WRAPPED.setRelease( this, ClosedResultSet.INSTANCE );
             pruneClosed();
             statement.pruneClosedResultSets();
         }
@@ -71,110 +89,110 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     public boolean next() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.next();
+            return wrappedResultSet().next();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean wasNull() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.wasNull();
+            return wrappedResultSet().wasNull();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public String getString(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getString( columnIndex );
+            return wrappedResultSet().getString( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean getBoolean(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBoolean( columnIndex );
+            return wrappedResultSet().getBoolean( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public byte getByte(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getByte( columnIndex );
+            return wrappedResultSet().getByte( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public short getShort(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getShort( columnIndex );
+            return wrappedResultSet().getShort( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public int getInt(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getInt( columnIndex );
+            return wrappedResultSet().getInt( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public long getLong(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getLong( columnIndex );
+            return wrappedResultSet().getLong( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public float getFloat(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getFloat( columnIndex );
+            return wrappedResultSet().getFloat( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public double getDouble(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getDouble( columnIndex );
+            return wrappedResultSet().getDouble( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
@@ -182,66 +200,66 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBigDecimal( columnIndex, scale );
+            return wrappedResultSet().getBigDecimal( columnIndex, scale );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public byte[] getBytes(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBytes( columnIndex );
+            return wrappedResultSet().getBytes( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Date getDate(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getDate( columnIndex );
+            return wrappedResultSet().getDate( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Time getTime(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getTime( columnIndex );
+            return wrappedResultSet().getTime( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Timestamp getTimestamp(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getTimestamp( columnIndex );
+            return wrappedResultSet().getTimestamp( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public InputStream getAsciiStream(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getAsciiStream( columnIndex );
+            return wrappedResultSet().getAsciiStream( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
@@ -249,110 +267,110 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     public InputStream getUnicodeStream(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getUnicodeStream( columnIndex );
+            return wrappedResultSet().getUnicodeStream( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public InputStream getBinaryStream(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBinaryStream( columnIndex );
+            return wrappedResultSet().getBinaryStream( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public String getString(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getString( columnLabel );
+            return wrappedResultSet().getString( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean getBoolean(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBoolean( columnLabel );
+            return wrappedResultSet().getBoolean( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public byte getByte(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getByte( columnLabel );
+            return wrappedResultSet().getByte( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public short getShort(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getShort( columnLabel );
+            return wrappedResultSet().getShort( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public int getInt(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getInt( columnLabel );
+            return wrappedResultSet().getInt( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public long getLong(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getLong( columnLabel );
+            return wrappedResultSet().getLong( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public float getFloat(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getFloat( columnLabel );
+            return wrappedResultSet().getFloat( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public double getDouble(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getDouble( columnLabel );
+            return wrappedResultSet().getDouble( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
@@ -360,66 +378,66 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBigDecimal( columnLabel, scale );
+            return wrappedResultSet().getBigDecimal( columnLabel, scale );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public byte[] getBytes(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBytes( columnLabel );
+            return wrappedResultSet().getBytes( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Date getDate(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getDate( columnLabel );
+            return wrappedResultSet().getDate( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Time getTime(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getTime( columnLabel );
+            return wrappedResultSet().getTime( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Timestamp getTimestamp(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getTimestamp( columnLabel );
+            return wrappedResultSet().getTimestamp( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public InputStream getAsciiStream(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getAsciiStream( columnLabel );
+            return wrappedResultSet().getAsciiStream( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
@@ -427,869 +445,869 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     public InputStream getUnicodeStream(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getUnicodeStream( columnLabel );
+            return wrappedResultSet().getUnicodeStream( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public InputStream getBinaryStream(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBinaryStream( columnLabel );
+            return wrappedResultSet().getBinaryStream( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public SQLWarning getWarnings() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getWarnings();
+            return wrappedResultSet().getWarnings();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void clearWarnings() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.clearWarnings();
+            wrappedResultSet().clearWarnings();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public String getCursorName() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getCursorName();
+            return wrappedResultSet().getCursorName();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public ResultSetMetaData getMetaData() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getMetaData();
+            return wrappedResultSet().getMetaData();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Object getObject(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getObject( columnIndex );
+            return wrappedResultSet().getObject( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Object getObject(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getObject( columnLabel );
+            return wrappedResultSet().getObject( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public int findColumn(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.findColumn( columnLabel );
+            return wrappedResultSet().findColumn( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Reader getCharacterStream(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getCharacterStream( columnIndex );
+            return wrappedResultSet().getCharacterStream( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Reader getCharacterStream(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getCharacterStream( columnLabel );
+            return wrappedResultSet().getCharacterStream( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBigDecimal( columnIndex );
+            return wrappedResultSet().getBigDecimal( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBigDecimal( columnLabel );
+            return wrappedResultSet().getBigDecimal( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean isBeforeFirst() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.isBeforeFirst();
+            return wrappedResultSet().isBeforeFirst();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean isAfterLast() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.isAfterLast();
+            return wrappedResultSet().isAfterLast();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean isFirst() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.isFirst();
+            return wrappedResultSet().isFirst();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean isLast() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.isLast();
+            return wrappedResultSet().isLast();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void beforeFirst() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.beforeFirst();
+            wrappedResultSet().beforeFirst();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void afterLast() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.afterLast();
+            wrappedResultSet().afterLast();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean first() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.first();
+            return wrappedResultSet().first();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean last() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.last();
+            return wrappedResultSet().last();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public int getRow() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getRow();
+            return wrappedResultSet().getRow();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean absolute(int row) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.absolute( row );
+            return wrappedResultSet().absolute( row );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean relative(int rows) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.relative( rows );
+            return wrappedResultSet().relative( rows );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean previous() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.previous();
+            return wrappedResultSet().previous();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public int getFetchDirection() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getFetchDirection();
+            return wrappedResultSet().getFetchDirection();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void setFetchDirection(int direction) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.setFetchDirection( direction );
+            wrappedResultSet().setFetchDirection( direction );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public int getFetchSize() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getFetchSize();
+            return wrappedResultSet().getFetchSize();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void setFetchSize(int rows) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.setFetchSize( rows );
+            wrappedResultSet().setFetchSize( rows );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public int getType() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getType();
+            return wrappedResultSet().getType();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public int getConcurrency() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getConcurrency();
+            return wrappedResultSet().getConcurrency();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean rowUpdated() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.rowUpdated();
+            return wrappedResultSet().rowUpdated();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean rowInserted() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.rowInserted();
+            return wrappedResultSet().rowInserted();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean rowDeleted() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.rowDeleted();
+            return wrappedResultSet().rowDeleted();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNull(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNull( columnIndex );
+            wrappedResultSet().updateNull( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBoolean(int columnIndex, boolean x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBoolean( columnIndex, x );
+            wrappedResultSet().updateBoolean( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateByte(int columnIndex, byte x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateByte( columnIndex, x );
+            wrappedResultSet().updateByte( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateShort(int columnIndex, short x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateShort( columnIndex, x );
+            wrappedResultSet().updateShort( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateInt(int columnIndex, int x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateInt( columnIndex, x );
+            wrappedResultSet().updateInt( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateLong(int columnIndex, long x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateLong( columnIndex, x );
+            wrappedResultSet().updateLong( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateFloat(int columnIndex, float x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateFloat( columnIndex, x );
+            wrappedResultSet().updateFloat( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateDouble(int columnIndex, double x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateDouble( columnIndex, x );
+            wrappedResultSet().updateDouble( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBigDecimal( columnIndex, x );
+            wrappedResultSet().updateBigDecimal( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateString(int columnIndex, String x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateString( columnIndex, x );
+            wrappedResultSet().updateString( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBytes(int columnIndex, byte[] x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBytes( columnIndex, x );
+            wrappedResultSet().updateBytes( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateDate(int columnIndex, Date x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateDate( columnIndex, x );
+            wrappedResultSet().updateDate( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateTime(int columnIndex, Time x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateTime( columnIndex, x );
+            wrappedResultSet().updateTime( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateTimestamp(int columnIndex, Timestamp x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateTimestamp( columnIndex, x );
+            wrappedResultSet().updateTimestamp( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateAsciiStream(int columnIndex, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateAsciiStream( columnIndex, x, length );
+            wrappedResultSet().updateAsciiStream( columnIndex, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBinaryStream(int columnIndex, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBinaryStream( columnIndex, x, length );
+            wrappedResultSet().updateBinaryStream( columnIndex, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateCharacterStream(int columnIndex, Reader x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateCharacterStream( columnIndex, x, length );
+            wrappedResultSet().updateCharacterStream( columnIndex, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateObject(int columnIndex, Object x, int scaleOrLength) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateObject( columnIndex, x, scaleOrLength );
+            wrappedResultSet().updateObject( columnIndex, x, scaleOrLength );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateObject(int columnIndex, Object x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateObject( columnIndex, x );
+            wrappedResultSet().updateObject( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNull(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNull( columnLabel );
+            wrappedResultSet().updateNull( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBoolean(String columnLabel, boolean x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBoolean( columnLabel, x );
+            wrappedResultSet().updateBoolean( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateByte(String columnLabel, byte x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateByte( columnLabel, x );
+            wrappedResultSet().updateByte( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateShort(String columnLabel, short x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateShort( columnLabel, x );
+            wrappedResultSet().updateShort( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateInt(String columnLabel, int x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateInt( columnLabel, x );
+            wrappedResultSet().updateInt( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateLong(String columnLabel, long x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateLong( columnLabel, x );
+            wrappedResultSet().updateLong( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateFloat(String columnLabel, float x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateFloat( columnLabel, x );
+            wrappedResultSet().updateFloat( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateDouble(String columnLabel, double x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateDouble( columnLabel, x );
+            wrappedResultSet().updateDouble( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBigDecimal( columnLabel, x );
+            wrappedResultSet().updateBigDecimal( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateString(String columnLabel, String x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateString( columnLabel, x );
+            wrappedResultSet().updateString( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBytes(String columnLabel, byte[] x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBytes( columnLabel, x );
+            wrappedResultSet().updateBytes( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateDate(String columnLabel, Date x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateDate( columnLabel, x );
+            wrappedResultSet().updateDate( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateTime(String columnLabel, Time x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateTime( columnLabel, x );
+            wrappedResultSet().updateTime( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateTimestamp(String columnLabel, Timestamp x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateTimestamp( columnLabel, x );
+            wrappedResultSet().updateTimestamp( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateAsciiStream(String columnLabel, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateAsciiStream( columnLabel, x, length );
+            wrappedResultSet().updateAsciiStream( columnLabel, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBinaryStream(String columnLabel, InputStream x, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBinaryStream( columnLabel, x, length );
+            wrappedResultSet().updateBinaryStream( columnLabel, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateCharacterStream(String columnLabel, Reader reader, int length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateCharacterStream( columnLabel, reader, length );
+            wrappedResultSet().updateCharacterStream( columnLabel, reader, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateObject(String columnLabel, Object x, int scaleOrLength) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateObject( columnLabel, x, scaleOrLength );
+            wrappedResultSet().updateObject( columnLabel, x, scaleOrLength );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateObject(String columnLabel, Object x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateObject( columnLabel, x );
+            wrappedResultSet().updateObject( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void insertRow() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.insertRow();
+            wrappedResultSet().insertRow();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateRow() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateRow();
+            wrappedResultSet().updateRow();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void deleteRow() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.deleteRow();
+            wrappedResultSet().deleteRow();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void refreshRow() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.refreshRow();
+            wrappedResultSet().refreshRow();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void cancelRowUpdates() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.cancelRowUpdates();
+            wrappedResultSet().cancelRowUpdates();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void moveToInsertRow() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.moveToInsertRow();
+            wrappedResultSet().moveToInsertRow();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void moveToCurrentRow() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.moveToCurrentRow();
+            wrappedResultSet().moveToCurrentRow();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
@@ -1301,844 +1319,844 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     public Object getObject(int columnIndex, Map<String, Class<?>> map) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getObject( columnIndex, map );
+            return wrappedResultSet().getObject( columnIndex, map );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Ref getRef(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getRef( columnIndex );
+            return wrappedResultSet().getRef( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Blob getBlob(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBlob( columnIndex );
+            return wrappedResultSet().getBlob( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Clob getClob(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getClob( columnIndex );
+            return wrappedResultSet().getClob( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Array getArray(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getArray( columnIndex );
+            return wrappedResultSet().getArray( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Object getObject(String columnLabel, Map<String, Class<?>> map) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getObject( columnLabel, map );
+            return wrappedResultSet().getObject( columnLabel, map );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Ref getRef(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getRef( columnLabel );
+            return wrappedResultSet().getRef( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Blob getBlob(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getBlob( columnLabel );
+            return wrappedResultSet().getBlob( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Clob getClob(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getClob( columnLabel );
+            return wrappedResultSet().getClob( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Array getArray(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getArray( columnLabel );
+            return wrappedResultSet().getArray( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Date getDate(int columnIndex, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getDate( columnIndex, cal );
+            return wrappedResultSet().getDate( columnIndex, cal );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Date getDate(String columnLabel, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getDate( columnLabel, cal );
+            return wrappedResultSet().getDate( columnLabel, cal );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Time getTime(int columnIndex, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getTime( columnIndex, cal );
+            return wrappedResultSet().getTime( columnIndex, cal );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Time getTime(String columnLabel, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getTime( columnLabel, cal );
+            return wrappedResultSet().getTime( columnLabel, cal );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getTimestamp( columnIndex, cal );
+            return wrappedResultSet().getTimestamp( columnIndex, cal );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getTimestamp( columnLabel, cal );
+            return wrappedResultSet().getTimestamp( columnLabel, cal );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public URL getURL(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getURL( columnIndex );
+            return wrappedResultSet().getURL( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public URL getURL(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getURL( columnLabel );
+            return wrappedResultSet().getURL( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateRef(int columnIndex, Ref x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateRef( columnIndex, x );
+            wrappedResultSet().updateRef( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateRef(String columnLabel, Ref x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateRef( columnLabel, x );
+            wrappedResultSet().updateRef( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBlob(int columnIndex, Blob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBlob( columnIndex, x );
+            wrappedResultSet().updateBlob( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBlob(String columnLabel, Blob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBlob( columnLabel, x );
+            wrappedResultSet().updateBlob( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateClob(int columnIndex, Clob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateClob( columnIndex, x );
+            wrappedResultSet().updateClob( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateClob(String columnLabel, Clob x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateClob( columnLabel, x );
+            wrappedResultSet().updateClob( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateArray(int columnIndex, Array x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateArray( columnIndex, x );
+            wrappedResultSet().updateArray( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateArray(String columnLabel, Array x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateArray( columnLabel, x );
+            wrappedResultSet().updateArray( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public RowId getRowId(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getRowId( columnIndex );
+            return wrappedResultSet().getRowId( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public RowId getRowId(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getRowId( columnLabel );
+            return wrappedResultSet().getRowId( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateRowId(int columnIndex, RowId x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateRowId( columnIndex, x );
+            wrappedResultSet().updateRowId( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateRowId(String columnLabel, RowId x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateRowId( columnLabel, x );
+            wrappedResultSet().updateRowId( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public int getHoldability() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getHoldability();
+            return wrappedResultSet().getHoldability();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean isClosed() throws SQLException {
         try {
-            return wrappedResultSet.isClosed();
+            return wrappedResultSet().isClosed();
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNString(int columnIndex, String nString) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNString( columnIndex, nString );
+            wrappedResultSet().updateNString( columnIndex, nString );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNString(String columnLabel, String nString) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNString( columnLabel, nString );
+            wrappedResultSet().updateNString( columnLabel, nString );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNClob(int columnIndex, NClob nClob) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNClob( columnIndex, nClob );
+            wrappedResultSet().updateNClob( columnIndex, nClob );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNClob(String columnLabel, NClob nClob) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNClob( columnLabel, nClob );
+            wrappedResultSet().updateNClob( columnLabel, nClob );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public NClob getNClob(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getNClob( columnIndex );
+            return wrappedResultSet().getNClob( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public NClob getNClob(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getNClob( columnLabel );
+            return wrappedResultSet().getNClob( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public SQLXML getSQLXML(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getSQLXML( columnIndex );
+            return wrappedResultSet().getSQLXML( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public SQLXML getSQLXML(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getSQLXML( columnLabel );
+            return wrappedResultSet().getSQLXML( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateSQLXML( columnIndex, xmlObject );
+            wrappedResultSet().updateSQLXML( columnIndex, xmlObject );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateSQLXML( columnLabel, xmlObject );
+            wrappedResultSet().updateSQLXML( columnLabel, xmlObject );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public String getNString(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getNString( columnIndex );
+            return wrappedResultSet().getNString( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public String getNString(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getNString( columnLabel );
+            return wrappedResultSet().getNString( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Reader getNCharacterStream(int columnIndex) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getNCharacterStream( columnIndex );
+            return wrappedResultSet().getNCharacterStream( columnIndex );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public Reader getNCharacterStream(String columnLabel) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getNCharacterStream( columnLabel );
+            return wrappedResultSet().getNCharacterStream( columnLabel );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNCharacterStream( columnIndex, x, length );
+            wrappedResultSet().updateNCharacterStream( columnIndex, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNCharacterStream( columnLabel, reader, length );
+            wrappedResultSet().updateNCharacterStream( columnLabel, reader, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateAsciiStream(int columnIndex, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateAsciiStream( columnIndex, x, length );
+            wrappedResultSet().updateAsciiStream( columnIndex, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBinaryStream(int columnIndex, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBinaryStream( columnIndex, x, length );
+            wrappedResultSet().updateBinaryStream( columnIndex, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateCharacterStream( columnIndex, x, length );
+            wrappedResultSet().updateCharacterStream( columnIndex, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateAsciiStream(String columnLabel, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateAsciiStream( columnLabel, x, length );
+            wrappedResultSet().updateAsciiStream( columnLabel, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBinaryStream(String columnLabel, InputStream x, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBinaryStream( columnLabel, x, length );
+            wrappedResultSet().updateBinaryStream( columnLabel, x, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateCharacterStream(String columnLabel, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateCharacterStream( columnLabel, reader, length );
+            wrappedResultSet().updateCharacterStream( columnLabel, reader, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBlob( columnIndex, inputStream, length );
+            wrappedResultSet().updateBlob( columnIndex, inputStream, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBlob( columnLabel, inputStream, length );
+            wrappedResultSet().updateBlob( columnLabel, inputStream, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateClob(int columnIndex, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateClob( columnIndex, reader, length );
+            wrappedResultSet().updateClob( columnIndex, reader, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateClob(String columnLabel, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateClob( columnLabel, reader, length );
+            wrappedResultSet().updateClob( columnLabel, reader, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNClob(int columnIndex, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNClob( columnIndex, reader, length );
+            wrappedResultSet().updateNClob( columnIndex, reader, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNClob(String columnLabel, Reader reader, long length) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateClob( columnLabel, reader, length );
+            wrappedResultSet().updateClob( columnLabel, reader, length );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNCharacterStream(int columnIndex, Reader x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNCharacterStream( columnIndex, x );
+            wrappedResultSet().updateNCharacterStream( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNCharacterStream(String columnLabel, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNCharacterStream( columnLabel, reader );
+            wrappedResultSet().updateNCharacterStream( columnLabel, reader );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateAsciiStream(int columnIndex, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateAsciiStream( columnIndex, x );
+            wrappedResultSet().updateAsciiStream( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBinaryStream(int columnIndex, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBinaryStream( columnIndex, x );
+            wrappedResultSet().updateBinaryStream( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateCharacterStream(int columnIndex, Reader x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateCharacterStream( columnIndex, x );
+            wrappedResultSet().updateCharacterStream( columnIndex, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateAsciiStream(String columnLabel, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateAsciiStream( columnLabel, x );
+            wrappedResultSet().updateAsciiStream( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBinaryStream(String columnLabel, InputStream x) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBinaryStream( columnLabel, x );
+            wrappedResultSet().updateBinaryStream( columnLabel, x );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateCharacterStream(String columnLabel, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateCharacterStream( columnLabel, reader );
+            wrappedResultSet().updateCharacterStream( columnLabel, reader );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBlob(int columnIndex, InputStream inputStream) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBlob( columnIndex, inputStream );
+            wrappedResultSet().updateBlob( columnIndex, inputStream );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateBlob(String columnLabel, InputStream inputStream) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateBlob( columnLabel, inputStream );
+            wrappedResultSet().updateBlob( columnLabel, inputStream );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateClob(int columnIndex, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateClob( columnIndex, reader );
+            wrappedResultSet().updateClob( columnIndex, reader );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateClob(String columnLabel, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateClob( columnLabel, reader );
+            wrappedResultSet().updateClob( columnLabel, reader );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNClob(int columnIndex, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNClob( columnIndex, reader );
+            wrappedResultSet().updateNClob( columnIndex, reader );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public void updateNClob(String columnLabel, Reader reader) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateNClob( columnLabel, reader );
+            wrappedResultSet().updateNClob( columnLabel, reader );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getObject( columnIndex, type );
+            return wrappedResultSet().getObject( columnIndex, type );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedResultSet.getObject( columnLabel, type );
+            return wrappedResultSet().getObject( columnLabel, type );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     // --- JDBC 4.2 //
 
     @Override
-    public void updateObject(int columnIndex, Object x, SQLType targetSqlType, int scaleOrLength)  throws SQLException {
+    public void updateObject(int columnIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateObject( columnIndex, x, targetSqlType, scaleOrLength );
+            wrappedResultSet().updateObject( columnIndex, x, targetSqlType, scaleOrLength );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
@@ -2149,7 +2167,7 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     public void updateObject(String columnLabel, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateObject( columnLabel, x, targetSqlType, scaleOrLength );
+            wrappedResultSet().updateObject( columnLabel, x, targetSqlType, scaleOrLength );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
@@ -2160,7 +2178,7 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     public void updateObject(int columnIndex, Object x, SQLType targetSqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateObject( columnIndex, x, targetSqlType );
+            wrappedResultSet().updateObject( columnIndex, x, targetSqlType );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
@@ -2171,7 +2189,7 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     public void updateObject(String columnLabel, Object x, SQLType targetSqlType) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedResultSet.updateObject( columnLabel, x, targetSqlType );
+            wrappedResultSet().updateObject( columnLabel, x, targetSqlType );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
@@ -2183,26 +2201,26 @@ public final class ResultSetWrapper extends AutoCloseableElement<ResultSetWrappe
     @Override
     public <T> T unwrap(Class<T> target) throws SQLException {
         try {
-            return wrappedResultSet.unwrap( target );
+            return wrappedResultSet().unwrap( target );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     public boolean isWrapperFor(Class<?> target) throws SQLException {
         try {
-            return wrappedResultSet.isWrapperFor( target );
+            return wrappedResultSet().isWrapperFor( target );
         } catch ( SQLException se ) {
             statement.getConnectionWrapper().getHandler().setFlushOnly( se );
             throw se;
-        }            
+        }
     }
 
     @Override
     protected boolean internalClosed() {
-        return wrappedResultSet == ClosedResultSet.INSTANCE;
+        return wrappedResultSet() == ClosedResultSet.INSTANCE;
     }
 
 }

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/StatementWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/StatementWrapper.java
@@ -6,6 +6,8 @@ package io.agroal.pool.wrapper;
 import io.agroal.pool.util.AutoCloseableElement;
 import io.agroal.pool.wrapper.closed.ClosedStatement;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -16,7 +18,22 @@ import java.sql.Statement;
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
  * @author <a href="jesper.pedersen@redhat.com">Jesper Pedersen</a>
  */
+@SuppressWarnings( "resource" )
 public class StatementWrapper extends AutoCloseableElement<StatementWrapper> implements Statement {
+
+    private static final VarHandle WRAPPED;
+
+    static {
+        try {
+            WRAPPED = MethodHandles.lookup().findVarHandle( StatementWrapper.class, "wrappedStatement", Statement.class );
+        } catch ( NoSuchFieldException | IllegalAccessException e ) {
+            throw new ExceptionInInitializerError( e );
+        }
+    }
+
+    private Statement wrappedStatement() {
+        return (Statement) WRAPPED.getAcquire( this );
+    }
 
     // --- //
 
@@ -32,12 +49,13 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     // tracks the state of closeOnCompletion
     private boolean closeOnCompletionState;
 
+    @SuppressWarnings( "unused" )
     private Statement wrappedStatement;
 
     public StatementWrapper(ConnectionWrapper connectionWrapper, Statement statement, boolean trackResources, AutoCloseableElement<StatementWrapper> head, boolean defaultHold) {
         super( head );
         connection = connectionWrapper;
-        wrappedStatement = statement;
+        WRAPPED.setRelease( this, statement );
         trackedResultSets = trackResources ? newHead() : null;
         holdState = defaultHold;
     }
@@ -64,17 +82,17 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     @Override
     public void close() throws SQLException {
         try {
-            if ( wrappedStatement != ClosedStatement.INSTANCE ) {
+            if ( wrappedStatement() != ClosedStatement.INSTANCE ) {
                 if ( trackedResultSets != null ) {
                     connection.addLeakedResultSets( trackedResultSets.closeAllAutocloseableElements() );
                 }
-                wrappedStatement.close();
+                wrappedStatement().close();
             }
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
         } finally {
-            wrappedStatement = ClosedStatement.INSTANCE;
+            WRAPPED.setRelease( this, ClosedStatement.INSTANCE );
             pruneClosed();
             connection.pruneClosedStatements();
         }
@@ -86,7 +104,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void clearWarnings() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.clearWarnings();
+            wrappedStatement().clearWarnings();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -97,7 +115,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final ResultSet executeQuery(String sql) throws SQLException {
         try {
             verifyEnlistment();
-            return trackResultSet( wrappedStatement.executeQuery( sql ) );
+            return trackResultSet( wrappedStatement().executeQuery( sql ) );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -108,7 +126,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int executeUpdate(String sql) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeUpdate( sql );
+            return wrappedStatement().executeUpdate( sql );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -119,7 +137,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int getMaxFieldSize() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getMaxFieldSize();
+            return wrappedStatement().getMaxFieldSize();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -130,7 +148,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void setMaxFieldSize(int max) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setMaxFieldSize( max );
+            wrappedStatement().setMaxFieldSize( max );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -141,7 +159,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int getMaxRows() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getMaxRows();
+            return wrappedStatement().getMaxRows();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -152,7 +170,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void setMaxRows(int max) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setMaxRows( max );
+            wrappedStatement().setMaxRows( max );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -163,7 +181,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void setEscapeProcessing(boolean enable) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setEscapeProcessing( enable );
+            wrappedStatement().setEscapeProcessing( enable );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -174,7 +192,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int getQueryTimeout() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getQueryTimeout();
+            return wrappedStatement().getQueryTimeout();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -185,7 +203,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void setQueryTimeout(int seconds) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setQueryTimeout( seconds );
+            wrappedStatement().setQueryTimeout( seconds );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -196,7 +214,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void cancel() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.cancel();
+            wrappedStatement().cancel();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -207,7 +225,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void setCursorName(String name) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setCursorName( name );
+            wrappedStatement().setCursorName( name );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -218,7 +236,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final boolean execute(String sql) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.execute( sql );
+            return wrappedStatement().execute( sql );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -229,7 +247,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final ResultSet getResultSet() throws SQLException {
         try {
             verifyEnlistment();
-            return trackResultSet( wrappedStatement.getResultSet() );
+            return trackResultSet( wrappedStatement().getResultSet() );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -240,7 +258,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int getUpdateCount() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getUpdateCount();
+            return wrappedStatement().getUpdateCount();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -251,7 +269,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final boolean getMoreResults() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getMoreResults();
+            return wrappedStatement().getMoreResults();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -262,7 +280,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int getFetchDirection() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getFetchDirection();
+            return wrappedStatement().getFetchDirection();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -273,7 +291,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void setFetchDirection(int direction) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setFetchDirection( direction );
+            wrappedStatement().setFetchDirection( direction );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -284,7 +302,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int getFetchSize() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getFetchSize();
+            return wrappedStatement().getFetchSize();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -295,7 +313,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void setFetchSize(int rows) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setFetchSize( rows );
+            wrappedStatement().setFetchSize( rows );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -306,7 +324,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int getResultSetConcurrency() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getResultSetConcurrency();
+            return wrappedStatement().getResultSetConcurrency();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -317,7 +335,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int getResultSetType() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getResultSetType();
+            return wrappedStatement().getResultSetType();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -328,7 +346,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void addBatch(String sql) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.addBatch( sql );
+            wrappedStatement().addBatch( sql );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -339,7 +357,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void clearBatch() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.clearBatch();
+            wrappedStatement().clearBatch();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -350,7 +368,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int[] executeBatch() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeBatch();
+            return wrappedStatement().executeBatch();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -367,7 +385,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final boolean getMoreResults(int current) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getMoreResults( current );
+            return wrappedStatement().getMoreResults( current );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -378,7 +396,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final ResultSet getGeneratedKeys() throws SQLException {
         try {
             verifyEnlistment();
-            return trackResultSet( wrappedStatement.getGeneratedKeys() );
+            return trackResultSet( wrappedStatement().getGeneratedKeys() );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -389,7 +407,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeUpdate( sql, autoGeneratedKeys );
+            return wrappedStatement().executeUpdate( sql, autoGeneratedKeys );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -400,7 +418,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeUpdate( sql, columnIndexes );
+            return wrappedStatement().executeUpdate( sql, columnIndexes );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -411,7 +429,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int executeUpdate(String sql, String[] columnNames) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeUpdate( sql, columnNames );
+            return wrappedStatement().executeUpdate( sql, columnNames );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -422,7 +440,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.execute( sql, autoGeneratedKeys );
+            return wrappedStatement().execute( sql, autoGeneratedKeys );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -433,7 +451,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final boolean execute(String sql, int[] columnIndexes) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.execute( sql, columnIndexes );
+            return wrappedStatement().execute( sql, columnIndexes );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -444,7 +462,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final boolean execute(String sql, String[] columnNames) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.execute( sql, columnNames );
+            return wrappedStatement().execute( sql, columnNames );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -455,7 +473,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final int getResultSetHoldability() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getResultSetHoldability();
+            return wrappedStatement().getResultSetHoldability();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -466,7 +484,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final boolean isPoolable() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.isPoolable();
+            return wrappedStatement().isPoolable();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -477,7 +495,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void setPoolable(boolean poolable) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setPoolable( poolable );
+            wrappedStatement().setPoolable( poolable );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -488,7 +506,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final void closeOnCompletion() throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.closeOnCompletion();
+            wrappedStatement().closeOnCompletion();
             closeOnCompletionState = true;
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
@@ -500,7 +518,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final boolean isCloseOnCompletion() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.isCloseOnCompletion();
+            return wrappedStatement().isCloseOnCompletion();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -511,7 +529,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public final SQLWarning getWarnings() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getWarnings();
+            return wrappedStatement().getWarnings();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -521,7 +539,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     @Override
     public final boolean isClosed() throws SQLException {
         try {
-            return wrappedStatement.isClosed();
+            return wrappedStatement().isClosed();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -534,7 +552,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public long getLargeUpdateCount() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getLargeUpdateCount();
+            return wrappedStatement().getLargeUpdateCount();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -545,7 +563,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public long getLargeMaxRows() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.getLargeMaxRows();
+            return wrappedStatement().getLargeMaxRows();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -556,7 +574,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public void setLargeMaxRows(long max) throws SQLException {
         try {
             verifyEnlistment();
-            wrappedStatement.setLargeMaxRows( max );
+            wrappedStatement().setLargeMaxRows( max );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -567,7 +585,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public long[] executeLargeBatch() throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeLargeBatch();
+            return wrappedStatement().executeLargeBatch();
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -578,7 +596,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public long executeLargeUpdate(String sql) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeLargeUpdate( sql );
+            return wrappedStatement().executeLargeUpdate( sql );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -589,7 +607,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeLargeUpdate( sql, autoGeneratedKeys );
+            return wrappedStatement().executeLargeUpdate( sql, autoGeneratedKeys );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -600,7 +618,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public long executeLargeUpdate(String sql, int[] columnIndexes) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeLargeUpdate( sql, columnIndexes );
+            return wrappedStatement().executeLargeUpdate( sql, columnIndexes );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -611,7 +629,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     public long executeLargeUpdate(String sql, String[] columnNames) throws SQLException {
         try {
             verifyEnlistment();
-            return wrappedStatement.executeLargeUpdate( sql, columnNames );
+            return wrappedStatement().executeLargeUpdate( sql, columnNames );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -623,7 +641,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     @Override
     public final <T> T unwrap(Class<T> target) throws SQLException {
         try {
-            return wrappedStatement.unwrap( target );
+            return wrappedStatement().unwrap( target );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -633,7 +651,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
     @Override
     public final boolean isWrapperFor(Class<?> target) throws SQLException {
         try {
-            return wrappedStatement.isWrapperFor( target );
+            return wrappedStatement().isWrapperFor( target );
         } catch ( SQLException se ) {
             connection.getHandler().setFlushOnly( se );
             throw se;
@@ -642,7 +660,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
 
     @Override
     public final String toString() {
-        return "wrapped[ " + wrappedStatement + " ]";
+        return "wrapped[ " + wrappedStatement() + " ]";
     }
 
     void pruneClosedResultSets() {
@@ -674,7 +692,7 @@ public class StatementWrapper extends AutoCloseableElement<StatementWrapper> imp
 
     @Override
     protected boolean internalClosed() {
-        return wrappedStatement == ClosedStatement.INSTANCE;
+        return wrappedStatement() == ClosedStatement.INSTANCE;
     }
 
 }

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/XAConnectionWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/XAConnectionWrapper.java
@@ -11,6 +11,8 @@ import javax.sql.ConnectionEventListener;
 import javax.sql.StatementEventListener;
 import javax.sql.XAConnection;
 import javax.transaction.xa.XAResource;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -19,6 +21,20 @@ import java.sql.SQLException;
  */
 public final class XAConnectionWrapper extends AutoCloseableElement<XAConnectionWrapper> implements XAConnection {
 
+    private static final VarHandle WRAPPED;
+
+    static {
+        try {
+            WRAPPED = MethodHandles.lookup().findVarHandle( XAConnectionWrapper.class, "wrappedXAConnection", XAConnection.class );
+        } catch ( NoSuchFieldException | IllegalAccessException e ) {
+            throw new ExceptionInInitializerError( e );
+        }
+    }
+
+    private XAConnection wrappedXAConnection() {
+        return (XAConnection) WRAPPED.getAcquire( this );
+    }
+
     // --- //
 
     // Collection of XAResources to close them on close(). If null Statements are not tracked.
@@ -26,12 +42,13 @@ public final class XAConnectionWrapper extends AutoCloseableElement<XAConnection
 
     private final ConnectionHandler handler;
 
+    @SuppressWarnings( "unused" )
     private XAConnection wrappedXAConnection;
 
     public XAConnectionWrapper(ConnectionHandler connectionHandler, XAConnection xaConnection, boolean trackResources) {
         super( null );
         handler = connectionHandler;
-        wrappedXAConnection = xaConnection;
+        WRAPPED.setRelease( this, xaConnection );
         trackedXAResources = trackResources ? newHead() : null;
     }
 
@@ -44,7 +61,7 @@ public final class XAConnectionWrapper extends AutoCloseableElement<XAConnection
     
     @Override
     protected boolean internalClosed() {
-        return wrappedXAConnection == ClosedXAConnection.INSTANCE;
+        return wrappedXAConnection() == ClosedXAConnection.INSTANCE;
     }
 
     // --- //
@@ -57,8 +74,8 @@ public final class XAConnectionWrapper extends AutoCloseableElement<XAConnection
     @Override
     public void close() throws SQLException {
         handler.traceConnectionOperation( "close()" );
-        if ( wrappedXAConnection != ClosedXAConnection.INSTANCE ) {
-            wrappedXAConnection = ClosedXAConnection.INSTANCE;
+        if ( wrappedXAConnection() != ClosedXAConnection.INSTANCE ) {
+            WRAPPED.setRelease( this, ClosedXAConnection.INSTANCE );
 
             if ( trackedXAResources != null ) {
                 trackedXAResources.closeAllAutocloseableElements();
@@ -95,25 +112,25 @@ public final class XAConnectionWrapper extends AutoCloseableElement<XAConnection
     @Override
     public void addConnectionEventListener(ConnectionEventListener listener) {
         handler.traceConnectionOperation( "addConnectionEventListener()" );
-        wrappedXAConnection.addConnectionEventListener( listener );
+        wrappedXAConnection().addConnectionEventListener( listener );
     }
 
     @Override
     public void removeConnectionEventListener(ConnectionEventListener listener) {
         handler.traceConnectionOperation( "removeConnectionEventListener()" );
-        wrappedXAConnection.removeConnectionEventListener( listener );
+        wrappedXAConnection().removeConnectionEventListener( listener );
     }
 
     @Override
     public void addStatementEventListener(StatementEventListener listener) {
         handler.traceConnectionOperation( "addStatementEventListener()" );
-        wrappedXAConnection.addStatementEventListener( listener );
+        wrappedXAConnection().addStatementEventListener( listener );
     }
 
     @Override
     public void removeStatementEventListener(StatementEventListener listener) {
         handler.traceConnectionOperation( "removeStatementEventListener()" );
-        wrappedXAConnection.removeStatementEventListener( listener );
+        wrappedXAConnection().removeStatementEventListener( listener );
     }
 
 }

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/XAResourceWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/XAResourceWrapper.java
@@ -4,6 +4,9 @@ import io.agroal.pool.ConnectionHandler;
 import io.agroal.pool.util.AutoCloseableElement;
 import io.agroal.pool.wrapper.closed.ClosedXAResource;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
@@ -13,20 +16,36 @@ import javax.transaction.xa.Xid;
  */
 public class XAResourceWrapper extends AutoCloseableElement<XAResourceWrapper> implements XAResource {
 
+    private static final VarHandle WRAPPED;
+
+    static {
+        try {
+            WRAPPED = MethodHandles.lookup().findVarHandle( XAResourceWrapper.class, "wrappedXAResource", XAResource.class );
+        } catch ( NoSuchFieldException | IllegalAccessException e ) {
+            throw new ExceptionInInitializerError( e );
+        }
+    }
+
+    private XAResource wrappedXAResource() {
+        return (XAResource) WRAPPED.getAcquire( this );
+    }
+
     // --- //
 
     private final ConnectionHandler handler;
+
+    @SuppressWarnings( "unused" )
     private XAResource wrappedXAResource;
 
     public XAResourceWrapper(ConnectionHandler connectionHandler, XAResource resource, AutoCloseableElement<XAResourceWrapper> head) {
         super( head );
         handler = connectionHandler;
-        wrappedXAResource = resource;
+        WRAPPED.setRelease( this, resource );
     }
-    
+
     @Override
     protected boolean internalClosed() {
-        return wrappedXAResource == ClosedXAResource.INSTANCE;
+        return wrappedXAResource() == ClosedXAResource.INSTANCE;
     }
 
     @Override
@@ -37,8 +56,8 @@ public class XAResourceWrapper extends AutoCloseableElement<XAResourceWrapper> i
     @Override
     public void close() throws Exception {
         handler.traceConnectionOperation( "xaResource.close()" );
-        if ( wrappedXAResource != ClosedXAResource.INSTANCE ) {
-            wrappedXAResource = ClosedXAResource.INSTANCE;
+        if ( wrappedXAResource() != ClosedXAResource.INSTANCE ) {
+            WRAPPED.setRelease( this, ClosedXAResource.INSTANCE );
         }
     }
 
@@ -47,61 +66,61 @@ public class XAResourceWrapper extends AutoCloseableElement<XAResourceWrapper> i
     @Override
     public void commit(Xid xid, boolean onePhase) throws XAException {
         handler.traceConnectionOperation( "xaResource.commit()" );
-        wrappedXAResource.commit( xid, onePhase );
+        wrappedXAResource().commit( xid, onePhase );
     }
 
     @Override
     public void end(Xid xid, int flags) throws XAException {
         handler.traceConnectionOperation( "xaResource.end()" );
-        wrappedXAResource.end( xid, flags );
+        wrappedXAResource().end( xid, flags );
     }
 
     @Override
     public void forget(Xid xid) throws XAException {
         handler.traceConnectionOperation( "xaResource.forget()" );
-        wrappedXAResource.forget( xid );
+        wrappedXAResource().forget( xid );
     }
 
     @Override
     public int getTransactionTimeout() throws XAException {
         handler.traceConnectionOperation( "xaResource.getTransactionTimeout()" );
-        return wrappedXAResource.getTransactionTimeout();
+        return wrappedXAResource().getTransactionTimeout();
     }
 
     @Override
     public boolean isSameRM(XAResource xares) throws XAException {
         handler.traceConnectionOperation( "xaResource.isSameRM()" );
-        return wrappedXAResource.isSameRM( xares );
+        return wrappedXAResource().isSameRM( xares );
     }
 
     @Override
     public int prepare(Xid xid) throws XAException {
         handler.traceConnectionOperation( "xaResource.prepare()" );
-        return wrappedXAResource.prepare( xid );
+        return wrappedXAResource().prepare( xid );
     }
 
     @Override
     public Xid[] recover(int flag) throws XAException {
         handler.traceConnectionOperation( "xaResource.recover()" );
-        return wrappedXAResource.recover( flag );
+        return wrappedXAResource().recover( flag );
     }
 
     @Override
     public void rollback(Xid xid) throws XAException {
         handler.traceConnectionOperation( "xaResource.rollback()" );
-        wrappedXAResource.rollback( xid );
+        wrappedXAResource().rollback( xid );
     }
 
     @Override
     public boolean setTransactionTimeout(int seconds) throws XAException {
         handler.traceConnectionOperation( "xaResource.setTransactionTimeout()" );
-        return wrappedXAResource.setTransactionTimeout( seconds );
+        return wrappedXAResource().setTransactionTimeout( seconds );
     }
 
     @Override
     public void start(Xid xid, int flags) throws XAException {
         handler.traceConnectionOperation( "xaResource.start()" );
-        wrappedXAResource.start( xid, flags );
+        wrappedXAResource().start( xid, flags );
     }
 
 }


### PR DESCRIPTION
replaces direct field access to the wrapped JDBC objects with `VarHandle` using getAcquire/setRelease memory ordering

this provides proper visibility guarantees across threads without the overhead of full volatile semantics