### PR TITLE
AG-308 - Apply setTransactionIsolation to all connections, not just the first

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionFactory.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionFactory.java
@@ -235,12 +235,16 @@ public final class ConnectionFactory implements ResourceRecoveryFactory {
         }
     }
 
+    @SuppressWarnings( "MagicConstant" )
     private Connection connectionSetup(Connection connection) throws SQLException {
         if ( connection == null ) {
             // AG-90: Driver can return null if the URL is not supported (see java.sql.Driver#connect() documentation)
             throw new SQLException( "Driver does not support the provided URL: " + configuration.jdbcUrl() );
         }
         loadDefaults( connection );
+        if ( configuration.jdbcTransactionIsolation().isDefined() ) {
+            connection.setTransactionIsolation( defaultIsolationLevel );
+        }
         connection.setAutoCommit( configuration.autoCommit() );
         if ( configuration.readOnly() ) {
             connection.setReadOnly( configuration.readOnly() );
@@ -256,13 +260,11 @@ public final class ConnectionFactory implements ResourceRecoveryFactory {
         return connection;
     }
 
-    @SuppressWarnings( "MagicConstant" )
     private void loadDefaults(Connection connection) throws SQLException {
         if ( defaultHoldability == null ) {
             synchronized ( jdbcProperties ) { // instead of "this", use a private final field for internal synchronization
                 if ( defaultHoldability == null ) {
                     if ( configuration.jdbcTransactionIsolation().isDefined() ) {
-                        connection.setTransactionIsolation( configuration.jdbcTransactionIsolation().level() );
                         defaultIsolationLevel = configuration.jdbcTransactionIsolation().level();
                     } else {
                         defaultIsolationLevel = connection.getTransactionIsolation();

--- a/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/NewConnectionTests.java
@@ -91,6 +91,20 @@ public class NewConnectionTests {
     }
 
     @Test
+    @DisplayName( "Test connection isolation is applied to all connections" )
+    void isolationAppliedToAllConnectionsTest() throws SQLException {
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( new AgroalDataSourceConfigurationSupplier().connectionPoolConfiguration( cp -> cp.maxSize( 2 ).connectionFactoryConfiguration( cf -> cf.jdbcTransactionIsolation( SERIALIZABLE ) ) ) ) ) {
+            Connection connection1 = dataSource.getConnection();
+            assertEquals( Connection.TRANSACTION_SERIALIZABLE, connection1.getTransactionIsolation(), "First connection should have the configured isolation level" );
+            Connection connection2 = dataSource.getConnection();
+            assertEquals( Connection.TRANSACTION_SERIALIZABLE, connection2.getTransactionIsolation(), "Second connection should also have the configured isolation level" );
+            logger.info( format( "Got isolation \"{0}\" from {1} and \"{2}\" from {3}", connection1.getTransactionIsolation(), connection1, connection2.getTransactionIsolation(), connection2 ) );
+            connection1.close();
+            connection2.close();
+        }
+    }
+
+    @Test
     @DisplayName( "Test connection readOnly status" )
     void readOnlyConnectionTest() throws SQLException {
         try ( AgroalDataSource dataSource = AgroalDataSource.from( new AgroalDataSourceConfigurationSupplier().connectionPoolConfiguration( cp -> cp.maxSize( 1 ) ) ) ) {


### PR DESCRIPTION
- #165 moved setTransactionIsolation inside the double-checked locking block in loadDefaults() as part of the lazy initialization of defaults. This inadvertently turned a per-connection call into a one-time-only call — only the first connection got the configured isolation level, while all subsequent connections kept the driver default.