### PR TITLE
AG-309 Clear held-over-commit state on flush

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
@@ -449,15 +449,21 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
         }
     }
 
+    // AG-309 - enlisted must be set to false after closing wrappers, not before.
+    // Closing a wrapper calls onConnectionWrapperClose() which checks !enlisted: if enlisted is
+    // already false it re-enters transactionEnd(), calling returnConnectionHandler() a second time.
+    // The second return finds the connection already CHECKED_IN and destroys it.
     @Override
     public void transactionEnd() throws SQLException {
-        enlisted = false;
         if ( !isHeldOverCommit ) {
             if ( enlistedOpenWrappers.closeAllAutocloseableElements() != 0 ) {
                 // should never happen, but it's here as a safeguard to prevent double returns in all cases.
                 fireOnWarning( connectionPool.getListeners(), "Closing open connection(s) on after completion" );
             }
+            enlisted = false;
             connectionPool.returnConnectionHandler( this );
+        } else {
+            enlisted = false;
         }
     }
 
@@ -488,10 +494,14 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
         }
     }
 
+    // AG-309 - clear isHeldOverCommit so that transactionEnd() returns the connection to the pool.
+    // Without this, an XA commit failure after transactionBeforeCompletion(true) leaves the
+    // connection with isHeldOverCommit=true and state=FLUSH, permanently leaking it.
     @Override
     public void setFlushOnly() {
         // Assumed currentState == State.CHECKED_OUT (or eventually in FLUSH already)
         stateUpdater.set( this, State.FLUSH );
+        isHeldOverCommit = false;
     }
 
     public void setFlushOnly(SQLException se) {
@@ -499,6 +509,7 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
         AgroalConnectionPoolConfiguration.ExceptionSorter exceptionSorter = connectionPool.getConfiguration().exceptionSorter();
         if ( exceptionSorter != null && exceptionSorter.isFatal( se ) ) {
             stateUpdater.set( this, State.FLUSH );
+            isHeldOverCommit = false;
         }
     }
 

--- a/agroal-test/src/test/java/io/agroal/test/narayana/HoldOnCompletionTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/narayana/HoldOnCompletionTests.java
@@ -11,6 +11,9 @@ import io.agroal.narayana.NarayanaTransactionIntegration;
 import io.agroal.test.MockConnection;
 import io.agroal.test.MockResultSet;
 import io.agroal.test.MockStatement;
+import io.agroal.test.MockXAConnection;
+import io.agroal.test.MockXADataSource;
+import io.agroal.test.MockXAResource;
 import jakarta.transaction.HeuristicMixedException;
 import jakarta.transaction.HeuristicRollbackException;
 import jakarta.transaction.NotSupportedException;
@@ -18,6 +21,8 @@ import jakarta.transaction.RollbackException;
 import jakarta.transaction.SystemException;
 import jakarta.transaction.TransactionManager;
 import jakarta.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -352,6 +357,89 @@ public class HoldOnCompletionTests {
             assertTrue( statement.isClosed(), "Non-holdable Statement should be closed after commit" );
             assertTrue( resultSet.isClosed(), "Non-holdable ResultSet should be closed after commit" );
             assertEquals( 1, dataSource.getMetrics().availableCount(), "Connection should return to pool after commit" );
+        }
+    }
+
+    // AG-309 - When XA commit fails on a connection with HOLD_CURSORS_OVER_COMMIT holdability,
+    // transactionBeforeCompletion(true) sets isHeldOverCommit=true before the commit call.
+    // If setFlushOnly() does not clear isHeldOverCommit, transactionEnd() skips returning
+    // the connection to the pool, leaking it in active state permanently.
+    @Test
+    @DisplayName( "Held connection returned to pool on XA commit failure" )
+    void testCommitFailureWithHoldability() throws SQLException {
+        TransactionManager txManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        TransactionSynchronizationRegistry txSyncRegistry = new com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple();
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .metricsEnabled()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .transactionIntegration( new NarayanaTransactionIntegration( txManager, txSyncRegistry ) )
+                        .connectionFactoryConfiguration( cf -> cf
+                                .connectionProviderClass( CommitFailingXADataSource.class ) ) );
+
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier ) ) {
+            txManager.begin();
+
+            Connection connection = dataSource.getConnection();
+            logger.info( format( "Got connection {0}", connection ) );
+
+            txManager.getTransaction().enlistResource( new MockXAResource.Empty() );
+
+            try {
+                txManager.commit();
+            } catch ( HeuristicMixedException | HeuristicRollbackException | RollbackException e ) {
+                logger.info( "Expected commit failure: " + e.getClass().getSimpleName() );
+            }
+
+            assertEquals( 0, dataSource.getMetrics().activeCount(), "Connection should not be stuck in active state" );
+        } catch ( NotSupportedException | SystemException | RollbackException e ) {
+            fail( "Exception: " + e.getMessage() );
+        }
+    }
+
+    // --- //
+
+    public static class CommitFailingXADataSource implements MockXADataSource {
+
+        @Override
+        public javax.sql.XAConnection getXAConnection() throws SQLException {
+            return new MockXAConnection() {
+                @Override
+                public XAResource getXAResource() {
+                    return new MockXAResource() {
+                        @Override
+                        public void commit(javax.transaction.xa.Xid xid, boolean onePhase) throws XAException {
+                            throw new XAException( XAException.XAER_RMFAIL );
+                        }
+                    };
+                }
+
+                @Override
+                public Connection getConnection() {
+                    return new HoldableConnection();
+                }
+            };
+        }
+    }
+
+    private static class HoldableConnection implements MockConnection {
+
+        private boolean closed;
+
+        @Override
+        public int getHoldability() {
+            return ResultSet.HOLD_CURSORS_OVER_COMMIT;
+        }
+
+        @Override
+        public void close() throws SQLException {
+            closed = true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
         }
     }
 

--- a/agroal-test/src/test/java/io/agroal/test/narayana/HoldOnCompletionTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/narayana/HoldOnCompletionTests.java
@@ -8,6 +8,8 @@ import io.agroal.api.AgroalDataSourceListener;
 import io.agroal.api.configuration.AgroalDataSourceConfiguration;
 import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
 import io.agroal.narayana.NarayanaTransactionIntegration;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.arjuna.recovery.RecoveryManager;
 import io.agroal.test.MockConnection;
 import io.agroal.test.MockResultSet;
 import io.agroal.test.MockStatement;
@@ -24,6 +26,7 @@ import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -32,10 +35,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -65,6 +72,17 @@ public class HoldOnCompletionTests {
     @BeforeAll
     static void setup() {
         registerMockDriver( ClosableConnection.class );
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        RecoveryManager.manager().terminate( true );
+        Path objectStoreDir = Path.of( arjPropertyManager.getObjectStoreEnvironmentBean().getObjectStoreDir() );
+        if ( Files.exists( objectStoreDir ) ) {
+            try ( Stream<Path> walk = Files.walk( objectStoreDir ) ) {
+                walk.sorted( Comparator.reverseOrder() ).forEach( p -> p.toFile().delete() );
+            }
+        }
     }
 
     @AfterAll

--- a/agroal-test/src/test/java/io/agroal/test/narayana/RecoveryTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/narayana/RecoveryTests.java
@@ -3,6 +3,7 @@
 
 package io.agroal.test.narayana;
 
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.arjuna.recovery.RecoveryManager;
 import com.arjuna.ats.internal.jta.recovery.arjunacore.XARecoveryModule;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
@@ -23,6 +24,7 @@ import jakarta.transaction.TransactionSynchronizationRegistry;
 import org.jboss.tm.XAResourceRecovery;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -39,11 +41,15 @@ import javax.sql.XAConnection;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -84,6 +90,17 @@ public class RecoveryTests {
         registerMockDriver();
         if ( Utils.isWindowsOS() ) {
             Utils.windowsTimerHack();
+        }
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        RecoveryManager.manager( DIRECT_MANAGEMENT ).terminate( true );
+        Path objectStoreDir = Path.of( arjPropertyManager.getObjectStoreEnvironmentBean().getObjectStoreDir() );
+        if ( Files.exists( objectStoreDir ) ) {
+            try ( Stream<Path> walk = Files.walk( objectStoreDir ) ) {
+                walk.sorted( Comparator.reverseOrder() ).forEach( p -> p.toFile().delete() );
+            }
         }
     }
 


### PR DESCRIPTION
I noticed the issue when I tried to update Agroal to 3.1 here: https://github.com/jbosstm/quickstart/pull/639

AG-279 introduced a re-entry bug in transactionEnd(): setting enlisted = false before closing wrappers allows onConnectionWrapperClose() to re-enter transactionEnd(), calling returnConnectionHandler() twice. The second call finds the connection already CHECKED_IN, treats it as FLUSH, and destroys the XA connection — breaking XA recovery.
 
Additionally, when an XA commit fails after transactionBeforeCompletion(true) has set isHeldOverCommit = true, the connection is permanently leaked: setFlushOnly() marks it for destruction but transactionEnd() skips returning it to the pool because isHeldOverCommit is still true. Clearing isHeldOverCommit in setFlushOnly() fixes this.
