### PR TITLE
Fix Logical error in ConnectionWrapper.hasTrackedStatements()

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/util/AutoCloseableElement.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/util/AutoCloseableElement.java
@@ -166,7 +166,7 @@ public abstract class AutoCloseableElement<T extends AutoCloseableElement<T>> im
                     boolean holdElement = next.isHeld() && !next.internalClosed();
                     if ( !holdElement && next instanceof ConnectionWrapper connectionWrapper ) {
                         connectionWrapper.closeNotHeldTrackedStatements();
-                        holdElement = !connectionWrapper.hasTrackedStatements();
+                        holdElement = connectionWrapper.hasTrackedStatements();
                     }
 
                     if ( !holdElement && current.setNextElement( next, next.nextElement ) && !next.internalClosed() ) {

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
@@ -145,7 +145,7 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
     }
 
     public boolean hasTrackedStatements() throws SQLException {
-        return trackedStatements != null && trackedStatements.isElementListEmpty();
+        return trackedStatements != null && !trackedStatements.isElementListEmpty();
     }
 
     // --- //


### PR DESCRIPTION
Seems to be a cosmetic error only since double negation keeps the flow on a valid path.

fixes #192