### PR TITLE
AG-312 - Allow configuration of data-source listeners in spring boot autoconfig

### DIFF
--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSource.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSource.java
@@ -60,6 +60,7 @@ public class AgroalDataSource implements io.agroal.api.AgroalDataSource, Initial
 
     private io.agroal.api.AgroalDataSource delegate;
     private String datasourceName = "<default>";
+    private List<AgroalDataSourceListener> dataSourceListeners;
 
     public AgroalDataSource() {
         datasourceConfiguration = new AgroalDataSourceConfigurationSupplier();
@@ -74,7 +75,10 @@ public class AgroalDataSource implements io.agroal.api.AgroalDataSource, Initial
         connectionPoolConfiguration.connectionFactoryConfiguration( connectionFactoryConfiguration );
         datasourceConfiguration.connectionPoolConfiguration( connectionPoolConfiguration );
 
-        delegate = io.agroal.api.AgroalDataSource.from( datasourceConfiguration, new LoggingListener( datasourceName ) );
+        if ( dataSourceListeners == null || dataSourceListeners.isEmpty() ) {
+            dataSourceListeners = List.of( new LoggingListener(datasourceName) );
+        }
+        delegate = io.agroal.api.AgroalDataSource.from(datasourceConfiguration, dataSourceListeners.toArray(new AgroalDataSourceListener[0]));
         logger.info( "Started DataSource {} connected to {}", datasourceName, getConfiguration().connectionPoolConfiguration().connectionFactoryConfiguration().jdbcUrl() );
     }
 
@@ -82,6 +86,10 @@ public class AgroalDataSource implements io.agroal.api.AgroalDataSource, Initial
 
     public void setName(String name) {
         datasourceName = name;
+    }
+
+    public void setDataSourceListeners(List<AgroalDataSourceListener> dataSourceListeners) {
+        this.dataSourceListeners = dataSourceListeners;
     }
 
     public void setImplementation(String name) {
@@ -284,6 +292,10 @@ public class AgroalDataSource implements io.agroal.api.AgroalDataSource, Initial
     }
 
     // --- //
+
+    public List<AgroalDataSourceListener> getDataSourceListeners() {
+        return dataSourceListeners == null ? List.of() : List.copyOf(dataSourceListeners);
+    }
 
     @Override
     public AgroalDataSourceConfiguration getConfiguration() {

--- a/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSourceAutoConfiguration.java
+++ b/agroal-spring-boot-starter/src/main/java/io/agroal/springframework/boot/AgroalDataSourceAutoConfiguration.java
@@ -5,6 +5,7 @@ package io.agroal.springframework.boot;
 
 import java.util.List;
 
+import io.agroal.api.AgroalDataSourceListener;
 import io.agroal.api.AgroalPoolInterceptor;
 import io.agroal.api.security.AgroalSecurityProvider;
 import io.agroal.narayana.NarayanaTransactionIntegration;
@@ -51,18 +52,21 @@ public class AgroalDataSourceAutoConfiguration {
     private final ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder;
     private final ObjectProvider<AgroalSecurityProvider> securityProvider;
     private final ObjectProvider<AgroalPoolInterceptor> poolInterceptor;
+    private final ObjectProvider<AgroalDataSourceListener> dataSourceListener;
 
     public AgroalDataSourceAutoConfiguration(
             ObjectProvider<JtaTransactionManager> jtaPlatformProvider,
             ObjectProvider<XAResourceRecoveryRegistry> recoveryRegistryProvider,
             ObjectProvider<AgroalDataSourceJndiBinder> jndiBinder,
             ObjectProvider<AgroalSecurityProvider> securityProvider,
-            ObjectProvider<AgroalPoolInterceptor> poolInterceptor ) {
+            ObjectProvider<AgroalPoolInterceptor> poolInterceptor,
+            ObjectProvider<AgroalDataSourceListener> dataSourceListener) {
         this.jtaPlatformProvider = jtaPlatformProvider;
         this.recoveryRegistryProvider = recoveryRegistryProvider;
         this.jndiBinder = jndiBinder;
         this.securityProvider = securityProvider;
         this.poolInterceptor = poolInterceptor;
+        this.dataSourceListener = dataSourceListener;
     }
 
     @Bean
@@ -124,6 +128,11 @@ public class AgroalDataSourceAutoConfiguration {
         recoveryCredentials.forEach( dataSource::addRecoveryCredential );
 
         poolInterceptor.forEach( dataSource::addPoolInterceptor );
+
+        var listeners = dataSourceListener.stream().toList();
+        if ( !listeners.isEmpty() ) {
+            dataSource.setDataSourceListeners( listeners );
+        }
 
         return dataSource;
     }

--- a/agroal-test/src/test/java/io/agroal/test/springframework/AgroalDataSourceConfigurationTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/springframework/AgroalDataSourceConfigurationTests.java
@@ -4,6 +4,7 @@
 package io.agroal.test.springframework;
 
 import dev.snowdrop.boot.narayana.autoconfigure.NarayanaAutoConfiguration;
+import io.agroal.api.AgroalDataSourceListener;
 import io.agroal.api.AgroalPoolInterceptor;
 import io.agroal.api.configuration.AgroalConnectionPoolConfiguration;
 import io.agroal.api.security.AgroalSecurityProvider;
@@ -13,6 +14,7 @@ import io.agroal.narayana.NarayanaTransactionIntegration;
 import io.agroal.springframework.boot.AgroalDataSource;
 import io.agroal.springframework.boot.AgroalDataSourceAutoConfiguration;
 import io.agroal.springframework.boot.metadata.AgroalDataSourcePoolMetadata;
+import io.agroal.test.ConnectionListener;
 import io.agroal.test.MockConnection;
 import io.agroal.test.MockDriver;
 import io.agroal.test.MockXAConnection;
@@ -291,6 +293,33 @@ class AgroalDataSourceConfigurationTests {
                 .run(context -> {
                     AgroalDataSource dataSource = context.getBean(AgroalDataSource.class);
                     assertThat(dataSource.getPoolInterceptors()).containsExactly(highPriorityInterceptor, mediumPriorityInterceptor, lowPriorityInterceptor);
+                });
+    }
+
+    @DisplayName("Default LoggingListener will be added to the DataSource when no beans of type AgroalDataSourceListener exist")
+    @Test
+    void testAgroalDefaultDataSourceListeners() {
+        runner
+                .run(context -> {
+                    AgroalDataSource dataSource = context.getBean(AgroalDataSource.class);
+                    var listener = assertThat(dataSource.getDataSourceListeners()).singleElement().actual();
+                    assertThat(listener.getClass().getName()).isEqualTo("io.agroal.springframework.boot.AgroalDataSource$LoggingListener");
+                });
+    }
+
+    @DisplayName("Any beans of type AgroalDataSourceListener will be added to the DataSource in order")
+    @Test
+    void testAgroalExplicitDataSourceListeners() {
+        AgroalDataSourceListener firstListener = new ConnectionListener();
+        AgroalDataSourceListener secondListener = new ConnectionListener();
+        AgroalDataSourceListener thirdListener = new ConnectionListener();
+        runner
+                .withBean("firstListener", AgroalDataSourceListener.class, () -> firstListener)
+                .withBean("secondListener", AgroalDataSourceListener.class, () -> secondListener)
+                .withBean("thirdListener", AgroalDataSourceListener.class, () -> thirdListener)
+                .run(context -> {
+                    AgroalDataSource dataSource = context.getBean(AgroalDataSource.class);
+                    assertThat(dataSource.getDataSourceListeners()).containsExactly(firstListener, secondListener, thirdListener);
                 });
     }
 


### PR DESCRIPTION
`io.agroal.api.AgroalDataSource` allow to specifiy a collection of data-source listeners, but `io.agroal.springframework.boot.AgroalDataSource` use a hard-coded `LoggingListener`.

This PR allows spring boot applications to define `AgroalDataSourceListener` beans to be used as data-source listeners. If no `AgroalDataSourceListener` beans are defined, the default `LoggingListener` is used.

Thanks in advance!