### PR TITLE
AG-311 - Fix connection leaks in wrapper list traversal, abort(), and transactionEnd()

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
@@ -456,12 +456,15 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
     @Override
     public void transactionEnd() throws SQLException {
         if ( !isHeldOverCommit ) {
-            if ( enlistedOpenWrappers.closeAllAutocloseableElements() != 0 ) {
-                // should never happen, but it's here as a safeguard to prevent double returns in all cases.
-                fireOnWarning( connectionPool.getListeners(), "Closing open connection(s) on after completion" );
+            try {
+                if ( enlistedOpenWrappers.closeAllAutocloseableElements() != 0 ) {
+                    // should never happen, but it's here as a safeguard to prevent double returns in all cases.
+                    fireOnWarning( connectionPool.getListeners(), "Closing open connection(s) on after completion" );
+                }
+            } finally {
+                enlisted = false;
+                connectionPool.returnConnectionHandler( this );
             }
-            enlisted = false;
-            connectionPool.returnConnectionHandler( this );
         } else {
             enlisted = false;
         }

--- a/agroal-pool/src/main/java/io/agroal/pool/util/AutoCloseableElement.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/util/AutoCloseableElement.java
@@ -169,10 +169,12 @@ public abstract class AutoCloseableElement<T extends AutoCloseableElement<T>> im
                         holdElement = connectionWrapper.hasTrackedStatements();
                     }
 
-                    if ( !holdElement && current.setNextElement( next, next.nextElement ) && !next.internalClosed() ) {
-                        next.beforeClose();
-                        next.close();
-                        count++;
+                    if ( !holdElement && current.setNextElement( next, next.nextElement ) ) {
+                        if ( !next.internalClosed() ) {
+                            next.beforeClose();
+                            next.close();
+                            count++;
+                        }
                     } else {
                         current = current.nextElement;
                     }

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
@@ -173,6 +173,8 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
         } catch ( SQLException se ) {
             handler.setFlushOnly( se );
             throw se;
+        } finally {
+            handler.onConnectionWrapperClose( this );
         }
     }
 

--- a/agroal-test/src/test/java/io/agroal/test/narayana/HoldOnCompletionTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/narayana/HoldOnCompletionTests.java
@@ -378,6 +378,39 @@ public class HoldOnCompletionTests {
         }
     }
 
+    @Test
+    @DisplayName( "Nested wrappers closed before commit should not leak" )
+    void testNestedWrappersClosedBeforeCommit() throws Exception {
+        TransactionManager txManager = com.arjuna.ats.jta.TransactionManager.transactionManager();
+        TransactionSynchronizationRegistry txSyncRegistry = new com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple();
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .metricsEnabled()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( 1 )
+                        .transactionIntegration( new NarayanaTransactionIntegration( txManager, txSyncRegistry ) ) );
+
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier ) ) {
+            txManager.begin();
+
+            // Simulate nested getConnection() calls as done by @Transactional beans calling
+            // other @Transactional beans, each acquiring a connection via try-with-resources.
+            // The outer connection is still open when the inner one is acquired and closed,
+            // leaving both wrappers in the enlistedOpenWrappers list.
+            try ( Connection outer = dataSource.getConnection() ) {
+                logger.info( format( "Got outer connection {0}", outer ) );
+                try ( Connection inner = dataSource.getConnection() ) {
+                    logger.info( format( "Got inner connection {0}", inner ) );
+                }
+            }
+
+            txManager.commit();
+
+            assertEquals( 0, dataSource.getMetrics().activeCount(), "No connections should be active after commit" );
+            assertEquals( 1, dataSource.getMetrics().availableCount(), "Connection should be returned to pool after commit" );
+        }
+    }
+
     // AG-309 - When XA commit fails on a connection with HOLD_CURSORS_OVER_COMMIT holdability,
     // transactionBeforeCompletion(true) sets isHeldOverCommit=true before the commit call.
     // If setFlushOnly() does not clear isHeldOverCommit, transactionEnd() skips returning


### PR DESCRIPTION
## Summary

- Fixes a connection leak in `closeNotHeldAutocloseableElements()` where a successful CAS removal of an already-closed wrapper caused the next element in the linked list to be skipped. This caused every other wrapper to remain in the list when 2+ wrappers were present simultaneously (e.g. nested `getConnection()` calls within a transaction), setting `isHeldOverCommit=true` and preventing `transactionEnd()` from returning the connection to the pool.
- Fixes `ConnectionWrapper.abort()` not calling `onConnectionWrapperClose()`, which left the connection handler permanently in CHECKED_OUT state.
- Wraps `transactionEnd()` close+warning in try-finally so the connection is always returned even if a listener throws a RuntimeException.

Related: https://github.com/quarkusio/quarkus/issues/54558

## Test plan

- [x] New test `testNestedWrappersClosedBeforeCommit` fails without the traversal fix, passes with it
- [x] All 200 existing tests pass (85 basic + 88 narayana + 27 spring)