### PR TITLE
AG-315 - Disable collaborative connection creation on virtual threads

### DIFF
--- a/.github/workflows/maven-action.yml
+++ b/.github/workflows/maven-action.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    name: Java 17 - Build
+    name: Java 21 - Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -21,7 +21,7 @@ jobs:
           cache: 'maven'
           distribution: 'temurin'
           java-package: jdk
-          java-version: '17'
+          java-version: '21'
       - run: mvn -B install
       - uses: actions/upload-artifact@v7
         with:
@@ -61,7 +61,7 @@ jobs:
     if: ${{ github.repository == 'agroal/agroal' && github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     needs: [ build, test ]
-    name: Java 17 - Rebuild and Deploy Snapshot Artifacts
+    name: Java 21 - Rebuild and Deploy Snapshot Artifacts
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -69,7 +69,7 @@ jobs:
           cache: 'maven'
           distribution: 'temurin'
           java-package: jdk
-          java-version: '17'
+          java-version: '21'
           server-id: jboss
           server-username: MAVEN_CI_USERNAME
           server-password: MAVEN_CI_PASSWORD

--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
@@ -12,6 +12,7 @@ import io.agroal.api.transaction.TransactionIntegration;
 import io.agroal.pool.MetricsRepository.EmptyMetricsRepository;
 import io.agroal.pool.util.PriorityScheduledExecutor;
 import io.agroal.pool.util.StampedCopyOnWriteArrayList;
+import io.agroal.pool.util.VirtualThreadUtil;
 import io.agroal.pool.util.XAConnectionAdaptor;
 
 import javax.sql.XAConnection;
@@ -347,7 +348,7 @@ public final class ConnectionPool implements Pool {
     private ConnectionHandler handlerFromSharedCache() throws SQLException {
         long acquisitionTimeout = configuration.acquisitionTimeout().isZero() ? MAX_VALUE : configuration.acquisitionTimeout().toNanos();
         long deadline = acquisitionTimeout == MAX_VALUE ? MAX_VALUE : nanoTime() + acquisitionTimeout;
-        boolean collaborate = true;
+        boolean collaborate = !VirtualThreadUtil.isVirtualThread();
         int retries = configuration.establishmentRetryAttempts();
         try {
             for ( int i = 0; ; i++ ) {

--- a/agroal-pool/src/main/java/io/agroal/pool/util/VirtualThreadUtil.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/util/VirtualThreadUtil.java
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.pool.util;
+
+/**
+ * Utility for virtual thread detection. On JDK < 21 this always returns false.
+ * On JDK 21+ the multi-release JAR overrides this with Thread.isVirtual().
+ */
+public final class VirtualThreadUtil {
+
+    private VirtualThreadUtil() {
+    }
+
+    public static boolean isVirtualThread() {
+        return false;
+    }
+}

--- a/agroal-pool/src/main/java/io/agroal/pool/util/VirtualThreadUtil.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/util/VirtualThreadUtil.java
@@ -3,6 +3,8 @@
 
 package io.agroal.pool.util;
 
+import java.util.concurrent.ExecutorService;
+
 /**
  * Utility for virtual thread detection. On JDK < 21 this always returns false.
  * On JDK 21+ the multi-release JAR overrides this with Thread.isVirtual().
@@ -14,5 +16,9 @@ public final class VirtualThreadUtil {
 
     public static boolean isVirtualThread() {
         return false;
+    }
+
+    public static ExecutorService newVirtualThreadPerTaskExecutor() {
+        return null;
     }
 }

--- a/agroal-pool/src/main/java21/io/agroal/pool/util/VirtualThreadUtil.java
+++ b/agroal-pool/src/main/java21/io/agroal/pool/util/VirtualThreadUtil.java
@@ -1,0 +1,17 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.pool.util;
+
+/**
+ * JDK 21+ override — uses Thread.isVirtual() directly.
+ */
+public final class VirtualThreadUtil {
+
+    private VirtualThreadUtil() {
+    }
+
+    public static boolean isVirtualThread() {
+        return Thread.currentThread().isVirtual();
+    }
+}

--- a/agroal-pool/src/main/java21/io/agroal/pool/util/VirtualThreadUtil.java
+++ b/agroal-pool/src/main/java21/io/agroal/pool/util/VirtualThreadUtil.java
@@ -3,6 +3,9 @@
 
 package io.agroal.pool.util;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 /**
  * JDK 21+ override — uses Thread.isVirtual() directly.
  */
@@ -13,5 +16,9 @@ public final class VirtualThreadUtil {
 
     public static boolean isVirtualThread() {
         return Thread.currentThread().isVirtual();
+    }
+
+    public static ExecutorService newVirtualThreadPerTaskExecutor() {
+        return Executors.newVirtualThreadPerTaskExecutor();
     }
 }

--- a/agroal-test/src/test/java/io/agroal/test/basic/VirtualThreadTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/VirtualThreadTests.java
@@ -1,0 +1,112 @@
+// Copyright (C) 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.basic;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
+import io.agroal.pool.util.VirtualThreadUtil;
+import io.agroal.test.MockConnection;
+import io.agroal.test.MockDriver;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.logging.Logger;
+
+import static io.agroal.test.AgroalTestGroup.CONCURRENCY;
+import static io.agroal.test.AgroalTestGroup.FUNCTIONAL;
+import static io.agroal.test.MockDriver.deregisterMockDriver;
+import static io.agroal.test.MockDriver.registerMockDriver;
+import static java.text.MessageFormat.format;
+import static java.time.Duration.ofMillis;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.logging.Logger.getLogger;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Tag( FUNCTIONAL )
+@Tag( CONCURRENCY )
+@EnabledForJreRange( min = JRE.JAVA_21 )
+public class VirtualThreadTests {
+
+    private static final Logger logger = getLogger( VirtualThreadTests.class.getName() );
+
+    @BeforeAll
+    static void setup() {
+        registerMockDriver( new PinningDriver() );
+    }
+
+    @AfterAll
+    static void teardown() {
+        deregisterMockDriver();
+    }
+
+    @Test
+    @DisplayName( "Virtual thread carrier pinning during connection creation" )
+    void virtualThreadCarrierPinningTest() throws SQLException, InterruptedException {
+        ExecutorService executor = VirtualThreadUtil.newVirtualThreadPerTaskExecutor();
+        assumeTrue( executor != null, "Multi-release JAR not active (reactor build)" );
+
+        int POOL_SIZE = 2, CONCURRENCY = 20, TIMEOUT_MS = 5000;
+        CountDownLatch latch = new CountDownLatch( CONCURRENCY );
+
+        AgroalDataSourceConfigurationSupplier configurationSupplier = new AgroalDataSourceConfigurationSupplier()
+                .connectionPoolConfiguration( cp -> cp
+                        .maxSize( POOL_SIZE )
+                        .acquisitionTimeout( ofMillis( TIMEOUT_MS ) )
+                );
+
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( configurationSupplier ) ) {
+            for ( int i = 0; i < CONCURRENCY; i++ ) {
+                executor.submit( () -> {
+                    try ( Connection connection = dataSource.getConnection() ) {
+                        Thread.sleep( 50 );
+                        latch.countDown();
+                    } catch ( SQLException e ) {
+                        fail( "Unexpected SQLException: " + e.getMessage() );
+                    } catch ( InterruptedException e ) {
+                        Thread.currentThread().interrupt();
+                    }
+                } );
+            }
+            assertTrue( latch.await( TIMEOUT_MS, MILLISECONDS ), "Virtual threads could not acquire connections within timeout — carrier pinning likely" );
+            logger.info( format( "All {0} virtual threads acquired connections successfully", CONCURRENCY ) );
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    // --- //
+
+    /**
+     * Simulates a JDBC driver that uses synchronized during connection creation,
+     * which pins virtual thread carriers.
+     */
+    public static class PinningDriver extends MockDriver.Empty {
+
+        private static final Object LOCK = new Object();
+
+        @Override
+        public Connection connect(String url, Properties info) throws SQLException {
+            synchronized ( LOCK ) {
+                try {
+                    Thread.sleep( 200 );
+                } catch ( InterruptedException e ) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            return new MockConnection.Empty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The AG-290 collaborative connection creation (`collaborate=true`) runs `createAndPoolConnection()` on the calling thread. On virtual threads this pins the carrier in the `handlerFromSharedCache()` CAS loop, causing CPU spikes and livelock under pool contention.

- On JDK 21+, set `collaborate=false` when the calling thread is virtual, offloading connection creation to the housekeeping executor
- On JDK < 21, behavior is unchanged (`collaborate=true`)
- Uses a multi-release JAR (`VirtualThreadUtil`) to detect virtual threads without reflection

## Test plan

- [x] All 30 Agroal tests pass
- [x] Verified with [Quarkus reproducer](https://github.com/quarkusio/quarkus/issues/54955) — health check responds in ~60ms (was timeout), no livelock
- [x] Verified with [PaperTrail reproducer](https://github.com/eggy03/PaperTrail-API-Quarkus/pull/3) in Docker with 0.15 CPU — zero zombie transactions, zero ARJUNA warnings
- [x] Verified that `collaborate=false` (pre-AG-290 behavior) eliminates the livelock, confirming AG-290 as root cause

Fixes https://redhat.atlassian.net/browse/AG-315