### PR TITLE
AG-317 - Support Request Boundaries

### DIFF
--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionHandler.java
@@ -142,6 +142,29 @@ public final class ConnectionHandler implements TransactionAware, Acquirable {
         return xaResource;
     }
 
+    // --- Request Boundaries (JDBC 4.3) --- //
+
+    // Called by the pool when the connection is handed out, marking the start of a request.
+    // Per the JDBC contract a duplicate beginRequest() without an intervening endRequest() is ignored by the driver.
+    public void beginRequest() throws SQLException {
+        try {
+            connection.beginRequest();
+        } catch ( SQLException se ) {
+            setFlushOnly( se );
+            throw se;
+        }
+    }
+
+    // Called by the pool when the connection is returned, marking the end of a request.
+    public void endRequest() throws SQLException {
+        try {
+            connection.endRequest();
+        } catch ( SQLException se ) {
+            setFlushOnly( se );
+            throw se;
+        }
+    }
+
     @SuppressWarnings( "MagicConstant" )
     public void resetConnection() throws SQLException {
         transactionActiveCheck = NO_ACTIVE_TRANSACTION;

--- a/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/ConnectionPool.java
@@ -476,6 +476,9 @@ public final class ConnectionPool implements Pool {
         metricsRepository.afterConnectionAcquire( metricsStamp );
         fireOnConnectionAcquired( listeners, checkedOutHandler );
 
+        // JDBC 4.3 Request Boundaries: signal the driver that a request begins as the connection leaves the pool
+        checkedOutHandler.beginRequest();
+
         if ( verifyEnlistment && !checkedOutHandler.isEnlisted() ) {
             switch ( configuration.transactionRequirement() ) {
                 case STRICT:
@@ -538,6 +541,8 @@ public final class ConnectionPool implements Pool {
         }
 
         try {
+            // JDBC 4.3 Request Boundaries: signal the driver that the request ended before the connection is reset for reuse
+            handler.endRequest();
             handler.resetConnection();
         } catch ( SQLException sqlException ) {
             fireOnWarning( listeners, sqlException );

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/ConnectionWrapper.java
@@ -837,6 +837,28 @@ public final class ConnectionWrapper extends AutoCloseableElement<ConnectionWrap
     }
 
     @Override
+    public void beginRequest() throws SQLException {
+        try {
+            handler.traceConnectionOperation( "beginRequest()" );
+            wrappedConnection().beginRequest();
+        } catch ( SQLException se ) {
+            handler.setFlushOnly( se );
+            throw se;
+        }
+    }
+
+    @Override
+    public void endRequest() throws SQLException {
+        try {
+            handler.traceConnectionOperation( "endRequest()" );
+            wrappedConnection().endRequest();
+        } catch ( SQLException se ) {
+            handler.setFlushOnly( se );
+            throw se;
+        }
+    }
+
+    @Override
     public String toString() {
         return "wrapped[" + wrappedConnection() + ( handler.isEnlisted() ? "]<<enrolled" : "]" );
     }

--- a/agroal-pool/src/main/java/io/agroal/pool/wrapper/closed/ClosedConnection.java
+++ b/agroal-pool/src/main/java/io/agroal/pool/wrapper/closed/ClosedConnection.java
@@ -304,6 +304,16 @@ public final class ClosedConnection implements Connection {
     }
 
     @Override
+    public void beginRequest() throws SQLException {
+        throw closed();
+    }
+
+    @Override
+    public void endRequest() throws SQLException {
+        throw closed();
+    }
+
+    @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
         throw closed();
     }

--- a/agroal-test/src/test/java/io/agroal/test/basic/PoolRequestBoundariesTests.java
+++ b/agroal-test/src/test/java/io/agroal/test/basic/PoolRequestBoundariesTests.java
@@ -1,0 +1,105 @@
+// Copyright (C) 2026 Red Hat, Inc. and individual contributors as indicated by the @author tags.
+// You may not use this file except in compliance with the Apache License, Version 2.0.
+
+package io.agroal.test.basic;
+
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.configuration.supplier.AgroalDataSourceConfigurationSupplier;
+import io.agroal.test.MockConnection;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.agroal.test.AgroalTestGroup.FUNCTIONAL;
+import static io.agroal.test.MockDriver.deregisterMockDriver;
+import static io.agroal.test.MockDriver.registerMockDriver;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests that the pool itself drives the JDBC 4.3 Request Boundaries API: {@code beginRequest()} on checkout and
+ * {@code endRequest()} on return, as recommended for connection pooling managers by the JDBC specification.
+ *
+ * @author <a href="gegastaldi@gmail.com">George Gastaldi</a>
+ */
+@Tag( FUNCTIONAL )
+public class PoolRequestBoundariesTests {
+
+    @BeforeAll
+    static void setupMockDriver() {
+        registerMockDriver( RequestBoundariesConnection.class );
+    }
+
+    @AfterAll
+    static void teardown() {
+        deregisterMockDriver();
+    }
+
+    @BeforeEach
+    void resetCounters() {
+        RequestBoundariesConnection.beginRequestCount.set( 0 );
+        RequestBoundariesConnection.endRequestCount.set( 0 );
+    }
+
+    // --- //
+
+    @Test
+    @DisplayName( "Pool calls beginRequest() on checkout and endRequest() on return" )
+    void poolDrivesRequestBoundaries() throws SQLException {
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( new AgroalDataSourceConfigurationSupplier().connectionPoolConfiguration( cp -> cp.maxSize( 1 ) ) ) ) {
+            Connection connection = dataSource.getConnection();
+
+            assertAll( () -> {
+                assertEquals( 1, RequestBoundariesConnection.beginRequestCount.get(), "Pool should call beginRequest() on checkout" );
+                assertEquals( 0, RequestBoundariesConnection.endRequestCount.get(), "endRequest() should not be called while the connection is in use" );
+            } );
+
+            connection.close();
+
+            assertAll( () -> {
+                assertEquals( 1, RequestBoundariesConnection.beginRequestCount.get(), "beginRequest() should not be called again on return" );
+                assertEquals( 1, RequestBoundariesConnection.endRequestCount.get(), "Pool should call endRequest() on return" );
+            } );
+        }
+    }
+
+    @Test
+    @DisplayName( "Each borrow cycle produces a matching begin/end pair" )
+    void requestBoundariesPerBorrowCycle() throws SQLException {
+        try ( AgroalDataSource dataSource = AgroalDataSource.from( new AgroalDataSourceConfigurationSupplier().connectionPoolConfiguration( cp -> cp.maxSize( 1 ) ) ) ) {
+            for ( int i = 0; i < 3; i++ ) {
+                dataSource.getConnection().close();
+            }
+
+            assertAll( () -> {
+                assertEquals( 3, RequestBoundariesConnection.beginRequestCount.get(), "Expected one beginRequest() per borrow" );
+                assertEquals( 3, RequestBoundariesConnection.endRequestCount.get(), "Expected one endRequest() per return" );
+            } );
+        }
+    }
+
+    // --- //
+
+    public static class RequestBoundariesConnection implements MockConnection {
+
+        private static final AtomicInteger beginRequestCount = new AtomicInteger();
+        private static final AtomicInteger endRequestCount = new AtomicInteger();
+
+        @Override
+        public void beginRequest() throws SQLException {
+            beginRequestCount.incrementAndGet();
+        }
+
+        @Override
+        public void endRequest() throws SQLException {
+            endRequestCount.incrementAndGet();
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds support for the JDBC 4.3 Request Boundaries API — `Connection.beginRequest()` and `Connection.endRequest()` — in Agroal.

Previously these methods were not implemented and fell back to the empty default methods of the `Connection` interface, so features that rely on explicit request boundaries — notably Oracle's **Transparent Application Continuity (TAC)**, which recommends explicitly calling `beginRequest`/`endRequest` — could not work through Agroal.

The change is delivered as two commits:

### 1. Implement Request Boundaries in `ConnectionWrapper`

- `ConnectionWrapper` implements `beginRequest()` / `endRequest()`, delegating to the underlying connection with the same trace / flush-only idiom as the other wrapped methods. (No `verifyEnlistment()` guard — request boundaries are transaction-agnostic session-lifecycle hints, not transactional operations.)
- `ClosedConnection` throws `SQLException` on both methods, so invoking them on a closed wrapper behaves consistently with the rest of the connection API instead of silently falling through to the interface no-ops.

This lets an application or framework explicitly bracket its work.

### 2. Drive Request Boundaries from the pool on checkout/return

Per the JDBC specification, the pooling manager is the intended caller of these methods:

> The pooling manager should call `beginRequest` on the underlying `Connection` when the application obtains it from the pool, and `endRequest` when the application returns it.

- `ConnectionHandler` gains `beginRequest()` / `endRequest()` delegating to the raw connection (with flush-only handling on error).
- `ConnectionPool.afterAcquire()` calls `beginRequest()` on checkout.
- `ConnectionPool.returnConnectionHandler()` calls `endRequest()` right before `resetConnection()` — reached only after `transactionIntegration.disassociate()` succeeds, so enlisted/XA connections defer the call until the transaction actually completes.
- `PoolRequestBoundariesTests` covers checkout/return and per-borrow begin/end pairing.

With this, Oracle TAC works transparently without the application having to bracket its work.

## Notes

The original request suggested hiding this behind a HikariCP-style opt-in configuration flag. Since `Connection.beginRequest()`/`endRequest()` have default no-op implementations in the JDBC interface, the calls are safe for drivers that do not override them, so no flag is added. Happy to introduce an opt-in flag if preferred.

## Verification

Full build clean; `PoolRequestBoundariesTests` and `BasicNarayanaTests` (transaction path) all pass.

- Fixes #206
- Jira: https://redhat.atlassian.net/browse/AG-317