### PR TITLE
Update Spring Boot to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <version.org.ops4j.pax.exam>4.14.0</version.org.ops4j.pax.exam>
         <version.org.ops4j.pax.url>3.0.1</version.org.ops4j.pax.url>
         <version.org.slf4j>2.0.17</version.org.slf4j>
-        <version.org.springframework.boot>4.0.6</version.org.springframework.boot>
+        <version.org.springframework.boot>4.1.1</version.org.springframework.boot>
         <!-- Maven plugins -->
         <version.bundle.plugin>6.0.2</version.bundle.plugin>
         <version.org.apache.servicemix.tooling>1.5.0</version.org.apache.servicemix.tooling>


### PR DESCRIPTION
Fixes #208

Update Spring Boot dependency from 4.0.6 to 4.1.1. No source code changes required.

Tested locally: full build (`mvn verify`) passes, all 29 tests green.