### PR TITLE
AG-316 - Replace sundrio with bom-builder3 for BOM generation

### DIFF
--- a/agroal-bom/pom.xml
+++ b/agroal-bom/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright © 2017 Red Hat, Inc. and individual contributors as indicated by the @author tags -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.agroal</groupId>
+        <artifactId>agroal-parent</artifactId>
+        <version>3.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>agroal-bom</artifactId>
+    <packaging>pom</packaging>
+    <name>Agroal BOM</name>
+    <description>Centralized dependencyManagement for the Agroal Project</description>
+    <properties>
+        <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
+        <sonar.skip>true</sonar.skip>
+    </properties>
+    <build>
+        <plugins>
+            <!--
+              The bom-builder3 plugin generates the dependencyManagement of this BOM from the reactor modules
+              and replaces this module's pom.xml with the generated BOM upon execution.
+            -->
+            <plugin>
+                <groupId>eu.maveniverse.maven.plugins</groupId>
+                <artifactId>bom-builder3</artifactId>
+                <executions>
+                    <execution>
+                        <id>build-bom</id>
+                        <goals>
+                            <goal>build-bom</goal>
+                        </goals>
+                        <configuration>
+                            <attach>true</attach>
+                            <bomArtifactId>agroal-bom</bomArtifactId>
+                            <bomName>Agroal BOM</bomName>
+                            <bomDescription>Centralized dependencyManagement for the Agroal Project</bomDescription>
+                            <!-- Skinny BOM: only the reactor modules, no direct/transitive dependencies -->
+                            <reactorDependencies>REACTOR</reactorDependencies>
+                            <directDependencies>NONE</directDependencies>
+                            <transitiveDependencies>NONE</transitiveDependencies>
+                            <!-- Exclude the test modules (equivalent to the previous sundrio "*:*test*" exclude) -->
+                            <dependencyExclusions>
+                                <dependencyExclusion>
+                                    <groupId>io.agroal</groupId>
+                                    <artifactId>agroal-test</artifactId>
+                                </dependencyExclusion>
+                                <dependencyExclusion>
+                                    <groupId>io.agroal</groupId>
+                                    <artifactId>agroal-integration-tests</artifactId>
+                                </dependencyExclusion>
+                            </dependencyExclusions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     </issueManagement>
     <modules>
         <module>agroal-api</module>
+        <module>agroal-bom</module>
         <module>agroal-integration-tests</module>
         <module>agroal-narayana</module>
         <module>agroal-pool</module>
@@ -79,11 +80,20 @@
         <version.bundle.plugin>6.0.2</version.bundle.plugin>
         <version.org.apache.servicemix.tooling>1.5.0</version.org.apache.servicemix.tooling>
         <version.de.thetaphi.forbiddenapis>3.10</version.de.thetaphi.forbiddenapis>
+        <version.eu.maveniverse.bom-builder3>1.3.4</version.eu.maveniverse.bom-builder3>
         <version.eu.somatik.serviceloader-maven-plugin>1.4.0</version.eu.somatik.serviceloader-maven-plugin>
         <version.org.apache.maven.plugins.maven-surefire-plugin>3.5.5</version.org.apache.maven.plugins.maven-surefire-plugin>
-        <version.sundrio>0.300.0</version.sundrio>
     </properties>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>eu.maveniverse.maven.plugins</groupId>
+                    <artifactId>bom-builder3</artifactId>
+                    <version>${version.eu.maveniverse.bom-builder3}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
@@ -134,36 +144,6 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>io.sundr</groupId>
-                <artifactId>sundr-maven-plugin</artifactId>
-                <version>${version.sundrio}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate-bom</goal>
-                        </goals>
-                        <configuration>
-                            <boms>
-                                <bom>
-                                    <artifactId>agroal-bom</artifactId>
-                                    <name>Agroal BOM</name>
-                                    <description>Centralized dependencyManagement for the Agroal Project</description>
-                                    <properties>
-                                        <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-                                        <sonar.skip>true</sonar.skip>
-                                    </properties>
-                                    <modules>
-                                        <excludes>
-                                            <exclude>*:*test*</exclude>
-                                        </excludes>
-                                    </modules>
-                                </bom>
-                            </boms>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Part of AG-316. Replaces the `io.sundr:sundr-maven-plugin` with `eu.maveniverse.maven.plugins:bom-builder3` (`1.3.4`) for generating `agroal-bom`.

## Why
`bom-builder3` is actively maintained under the Maveniverse project and, per its [README](https://github.com/maveniverse/bom-builder-maven-plugin), produces a Maven 3 (and 4) consumable BOM.

## What changed
- **New `agroal-bom` module.** `bom-builder3` requires a dedicated `pom`-packaging module with no submodules, whose `pom.xml` is *replaced* by the generated BOM at build time. So `agroal-bom` is now a real reactor module rather than a synthetic artifact produced from the parent reactor.
- **Parent `pom.xml`:** added the `agroal-bom` module, dropped the `sundr-maven-plugin` block and `version.sundrio` property, added `version.eu.maveniverse.bom-builder3`.
- Configured as a **skinny** BOM (reactor modules only), excluding the test modules `agroal-test` and `agroal-integration-tests` — the equivalent of the old `*:*test*` exclude.

## Result
The generated BOM is unchanged in content — the four publishable modules, with Maven-Central-required metadata (url, licenses, developers, scm) inherited from the top-level POM:

- `io.agroal:agroal-api`
- `io.agroal:agroal-narayana`
- `io.agroal:agroal-pool`
- `io.agroal:agroal-spring-boot-starter`

## Verification
`mvn install` → `BUILD SUCCESS`; confirmed the installed `agroal-bom-3.3-SNAPSHOT.pom` is the generated BOM with the expected `dependencyManagement`.